### PR TITLE
chore: downgrade fastify multipart

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   server:
     dependencies:
       '@fastify/multipart':
-        specifier: ^9.0.3
-        version: 9.0.3
+        specifier: ^8.0.0
+        version: 8.3.1
       '@fastify/static':
         specifier: ^6.12.0
         version: 6.12.0
@@ -365,8 +365,8 @@ packages:
   '@fastify/middie@8.3.3':
     resolution: {integrity: sha512-+WHavMQr9CNTZoy2cjoDxoWp76kZ3JKjAtZj5sXNlxX5XBzHig0TeCPfPc+1+NQmliXtndT3PFwAjrQHE/6wnQ==}
 
-  '@fastify/multipart@9.0.3':
-    resolution: {integrity: sha512-pJogxQCrT12/6I5Fh6jr3narwcymA0pv4B0jbC7c6Bl9wnrxomEUnV0d26w6gUls7gSXmhG8JGRMmHFIPsxt1g==}
+  '@fastify/multipart@8.3.1':
+    resolution: {integrity: sha512-pncbnG28S6MIskFSVRtzTKE9dK+GrKAJl0NbaQ/CG8ded80okWFsYKzSlP9haaLNQhNRDOoHqmGQNvgbiPVpWQ==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -2029,9 +2029,6 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
-  secure-json-parse@3.0.2:
-    resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
-
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -2096,6 +2093,10 @@ packages:
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  stream-wormhole@1.1.0:
+    resolution: {integrity: sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==}
+    engines: {node: '>=4.0.0'}
 
   string-to-stream@3.0.1:
     resolution: {integrity: sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==}
@@ -2583,13 +2584,14 @@ snapshots:
       path-to-regexp: 6.3.0
       reusify: 1.1.0
 
-  '@fastify/multipart@9.0.3':
+  '@fastify/multipart@8.3.1':
     dependencies:
       '@fastify/busboy': 3.2.0
       '@fastify/deepmerge': 2.0.2
       '@fastify/error': 4.2.0
-      fastify-plugin: 5.0.1
-      secure-json-parse: 3.0.2
+      fastify-plugin: 4.5.1
+      secure-json-parse: 2.7.0
+      stream-wormhole: 1.1.0
 
   '@fastify/send@2.1.0':
     dependencies:
@@ -4448,8 +4450,6 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
-  secure-json-parse@3.0.2: {}
-
   semver@7.7.2: {}
 
   serialize-javascript@6.0.2:
@@ -4503,6 +4503,8 @@ snapshots:
   statuses@2.0.1: {}
 
   stream-shift@1.0.3: {}
+
+  stream-wormhole@1.1.0: {}
 
   string-to-stream@3.0.1:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "prisma:studio": "prisma studio"
   },
   "dependencies": {
-    "@fastify/multipart": "^9.0.3",
+    "@fastify/multipart": "^8.0.0",
     "@fastify/static": "^6.12.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",


### PR DESCRIPTION
## Summary
- downgrade @fastify/multipart to v8

## Testing
- `pnpm --filter server install`
- `pnpm --filter server build && pnpm --filter server start` *(fails: Property 'collection' does not exist on type 'PrismaService')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d5510258832680c517d43292b991