### PR TITLE
Add run cancellation, timeout and request mapping

### DIFF
--- a/server/src/prisma/enums.ts
+++ b/server/src/prisma/enums.ts
@@ -1,0 +1,23 @@
+export enum RunStatus {
+  queued = 'queued',
+  running = 'running',
+  success = 'success',
+  fail = 'fail',
+  partial = 'partial',
+  timeout = 'timeout',
+  error = 'error',
+  cancelled = 'cancelled',
+}
+
+export enum HealthStatus {
+  HEALTHY = 'HEALTHY',
+  DEGRADED = 'DEGRADED',
+  UNHEALTHY = 'UNHEALTHY',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export enum StepStatus {
+  success = 'success',
+  fail = 'fail',
+}
+

--- a/server/src/runs/dto/create-run.dto.ts
+++ b/server/src/runs/dto/create-run.dto.ts
@@ -16,4 +16,8 @@ export class CreateRunDto {
 
   @IsOptional() @IsBoolean()
   insecure?: boolean;
+
+  // run-level max duration
+  @IsOptional() @IsInt() @Min(1)
+  maxDurationMs?: number;
 }

--- a/server/src/runs/runs.controller.ts
+++ b/server/src/runs/runs.controller.ts
@@ -17,6 +17,11 @@ export class RunsController {
     return this.svc.get(runId);
   }
 
+  @Post('api/runs/:runId/cancel')
+  async cancel(@Param('runId') runId: string) {
+    return this.svc.cancel(runId);
+  }
+
   @Get('api/runs/:runId/steps')
   async steps(@Param('runId') runId: string) {
     return this.svc.listSteps(runId);

--- a/server/src/runs/runs.executor.ts
+++ b/server/src/runs/runs.executor.ts
@@ -1,12 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { NewmanRunner } from '../runner/newman-runner';
+import { RunStatus, HealthStatus } from '../prisma/enums';
 
 type EnqueueOpts = {
   timeoutRequestMs?: number;
   delayRequestMs?: number;
   bail?: boolean;
   insecure?: boolean;
+  maxDurationMs?: number;
 };
 
 @Injectable()
@@ -14,6 +16,7 @@ export class RunsExecutor {
   private readonly logger = new Logger(RunsExecutor.name);
   private queue: { runId: string; opts: EnqueueOpts }[] = [];
   private busy = false;
+  private current: { runId: string; opts: EnqueueOpts } | null = null;
 
   constructor(private readonly prisma: PrismaService, private readonly newman: NewmanRunner) {}
 
@@ -22,14 +25,43 @@ export class RunsExecutor {
     this.tick().catch(err => this.logger.error(err));
   }
 
+  async cancel(runId: string) {
+    if (this.current?.runId === runId) {
+      this.newman.cancel(runId, 'cancel');
+      return { ok: true, mode: 'running' };
+    }
+    const idx = this.queue.findIndex(q => q.runId === runId);
+    if (idx >= 0) {
+      this.queue.splice(idx, 1);
+      const now = new Date();
+      await this.prisma.run.update({
+        where: { id: runId },
+        data: {
+          status: RunStatus.cancelled,
+          endedAt: now,
+          durationMs: 0,
+          totalRequests: 0,
+          successRequests: 0,
+          failedRequests: 0,
+          health: HealthStatus.UNKNOWN,
+          errorMsg: 'run cancelled (not started)',
+        },
+      });
+      return { ok: true, mode: 'queued' };
+    }
+    return { ok: false };
+  }
+
   private async tick(): Promise<void> {
     if (this.busy) return;
     const next = this.queue.shift();
     if (!next) return;
     this.busy = true;
+    this.current = next;
     try {
       await this.newman.run(next.runId, next.opts);
     } finally {
+      this.current = null;
       this.busy = false;
       if (this.queue.length) await this.tick();
     }

--- a/server/test/runs-cancel-timeout.e2e-spec.ts
+++ b/server/test/runs-cancel-timeout.e2e-spec.ts
@@ -1,0 +1,236 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import request from 'supertest';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import multipart from '@fastify/multipart';
+import { AppModule } from '../src/app.module';
+
+function makeCollection() {
+  return {
+    info: {
+      name: 'CancelTimeout Demo',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    item: [
+      {
+        name: 'Slow',
+        item: [
+          {
+            name: 'Slow A',
+            request: { method: 'GET', url: '{{baseUrl}}/slow/a' },
+            event: [
+              {
+                listen: 'test',
+                script: {
+                  type: 'text/javascript',
+                  exec: ["pm.test('200',()=>pm.response.to.have.status(200));"],
+                },
+              },
+            ],
+          },
+          {
+            name: 'Slow B',
+            request: { method: 'GET', url: '{{baseUrl}}/slow/b' },
+            event: [
+              {
+                listen: 'test',
+                script: {
+                  type: 'text/javascript',
+                  exec: ["pm.test('200',()=>pm.response.to.have.status(200));"],
+                },
+              },
+            ],
+          },
+          {
+            name: 'Slow C',
+            request: {
+              method: 'POST',
+              url: '{{baseUrl}}/slow/c',
+              body: { mode: 'raw', raw: '{}' },
+              header: [{ key: 'Content-Type', value: 'application/json' }],
+            },
+            event: [
+              {
+                listen: 'test',
+                script: {
+                  type: 'text/javascript',
+                  exec: ["pm.test('201',()=>pm.response.to.have.status(201));"],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeEnv(baseUrl: string) {
+  return {
+    name: 'ct-env',
+    values: [{ key: 'baseUrl', value: baseUrl, type: 'text', enabled: true }],
+  };
+}
+
+function startMockServer(delayMs = 300): Promise<{ server: http.Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const respond = (code: number, body: any) => {
+        setTimeout(() => {
+          res.statusCode = code;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(body));
+        }, delayMs);
+      };
+      if (req.method === 'GET' && req.url === '/slow/a') return respond(200, { a: 1 });
+      if (req.method === 'GET' && req.url === '/slow/b') return respond(200, { b: 2 });
+      if (req.method === 'POST' && req.url === '/slow/c') {
+        let buf = '';
+        req.on('data', (c) => (buf += c));
+        req.on('end', () => respond(201, { ok: true }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ ok: false }));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function pollRun(app: INestApplication, runId: string, timeoutMs = 8000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await request(app.getHttpServer()).get(`/api/runs/${runId}`).expect(200);
+    if (['success', 'partial', 'fail', 'timeout', 'error', 'cancelled'].includes(res.body.status))
+      return res.body;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('run did not finish in time');
+}
+
+describe('Cancel & Timeout (e2e)', () => {
+  let app: NestFastifyApplication;
+  let mock: { server: http.Server; baseUrl: string };
+
+  beforeAll(async () => {
+    mock = await startMockServer(200);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    // register multipart parser as in bootstrap
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await app.register(multipart as any);
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    mock.server.close();
+  });
+
+  it('maps RunStep.requestId to indexed CollectionRequest', async () => {
+    const col = makeCollection();
+    const env = makeEnv(mock.baseUrl);
+
+    const up = await request(app.getHttpServer())
+      .post('/api/collections/upload')
+      .attach('collection', Buffer.from(JSON.stringify(col)), {
+        filename: 'col.json',
+        contentType: 'application/json',
+      })
+      .attach('env', Buffer.from(JSON.stringify(env)), {
+        filename: 'env.json',
+        contentType: 'application/json',
+      })
+      .expect(201);
+    const collectionId = up.body.collectionId;
+
+    const start = await request(app.getHttpServer())
+      .post(`/api/collections/${collectionId}/run`)
+      .send({ delayRequestMs: 10, environmentId: (await request(app.getHttpServer()).get(`/api/collections/${collectionId}`)).body.envs[0].id })
+      .expect(201);
+
+    const runId = start.body.runId;
+    const finished = await pollRun(app, runId);
+    expect(finished.status).toBe('success');
+
+    const steps = await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).expect(200);
+    expect(steps.body.length).toBe(3);
+    for (const s of steps.body) {
+      expect(s.requestId).toBeTruthy();
+      expect(s.request?.path).toMatch(/Slow (A|B|C)$/);
+    }
+  });
+
+  it('cancels a running run', async () => {
+    const col = makeCollection();
+    const env = makeEnv(mock.baseUrl);
+    const up = await request(app.getHttpServer())
+      .post('/api/collections/upload')
+      .attach('collection', Buffer.from(JSON.stringify(col)), {
+        filename: 'col.json',
+        contentType: 'application/json',
+      })
+      .attach('env', Buffer.from(JSON.stringify(env)), {
+        filename: 'env.json',
+        contentType: 'application/json',
+      })
+      .expect(201);
+    const collectionId = up.body.collectionId;
+    const envId = (
+      await request(app.getHttpServer()).get(`/api/collections/${collectionId}`)
+    ).body.envs[0].id;
+
+    const start = await request(app.getHttpServer())
+      .post(`/api/collections/${collectionId}/run`)
+      .send({ environmentId: envId, delayRequestMs: 100 })
+      .expect(201);
+    const runId = start.body.runId;
+
+    await new Promise(r => setTimeout(r, 50));
+    await request(app.getHttpServer()).post(`/api/runs/${runId}/cancel`).expect(201);
+
+    const finished = await pollRun(app, runId);
+    expect(finished.status).toBe('cancelled');
+    await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).expect(200);
+  });
+
+  it('times out a run with maxDurationMs', async () => {
+    const col = makeCollection();
+    const env = makeEnv(mock.baseUrl);
+    const up = await request(app.getHttpServer())
+      .post('/api/collections/upload')
+      .attach('collection', Buffer.from(JSON.stringify(col)), {
+        filename: 'col.json',
+        contentType: 'application/json',
+      })
+      .attach('env', Buffer.from(JSON.stringify(env)), {
+        filename: 'env.json',
+        contentType: 'application/json',
+      })
+      .expect(201);
+    const collectionId = up.body.collectionId;
+    const envId = (
+      await request(app.getHttpServer()).get(`/api/collections/${collectionId}`)
+    ).body.envs[0].id;
+
+    const start = await request(app.getHttpServer())
+      .post(`/api/collections/${collectionId}/run`)
+      .send({ environmentId: envId, maxDurationMs: 50, delayRequestMs: 100 })
+      .expect(201);
+    const runId = start.body.runId;
+
+    const finished = await pollRun(app, runId);
+    expect(finished.status).toBe('timeout');
+    await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).expect(200);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow configuring maxDurationMs to auto-timeout runs and expose cancel endpoint
- map Newman steps to collection requests via requestId and expose in step listing
- e2e tests for requestId mapping, cancelling and timing out runs

## Testing
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ab3472c2448326ad97d98b3b78cf49