### PR TITLE
feat: enrich run SSE and health scoring with pagination

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
+      eventsource:
+        specifier: ^4.0.0
+        version: 4.0.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.11)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
@@ -1730,6 +1733,14 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.5:
+    resolution: {integrity: sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==}
+    engines: {node: '>=20.0.0'}
+
+  eventsource@4.0.0:
+    resolution: {integrity: sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==}
+    engines: {node: '>=20.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -5434,6 +5445,12 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.0.5: {}
+
+  eventsource@4.0.0:
+    dependencies:
+      eventsource-parser: 3.0.5
 
   execa@5.1.1:
     dependencies:

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,3 +13,6 @@ SWAGGER_VERSION="0.0.1"
 # File uploads
 UPLOAD_DIR=./uploads
 MAX_UPLOAD_MB=10
+
+# Health SLA threshold for p95 (optional)
+HEALTH_P95_SLA_MS=800

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^6.20.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
+    "eventsource": "^4.0.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
     "prisma": "^5.13.0",

--- a/server/src/collections/collections.controller.ts
+++ b/server/src/collections/collections.controller.ts
@@ -1,10 +1,12 @@
 import {
+  Body,
   Controller,
   Get,
   Post,
   Req,
   Query,
   Param,
+  Patch,
   DefaultValuePipe,
   ParseBoolPipe,
 } from '@nestjs/common';
@@ -12,6 +14,7 @@ import { CollectionsService } from './collections.service';
 import { FastifyRequest } from 'fastify';
 import { ListCollectionsQueryDto } from './dto/list-collections.dto';
 import type { Multipart } from '@fastify/multipart';
+import { UpdateRequestDto } from './dto/update-request.dto';
 
 @Controller('api/collections')
 export class CollectionsController {
@@ -81,5 +84,14 @@ export class CollectionsController {
     @Query('replace', new DefaultValuePipe(true), ParseBoolPipe) replace: boolean,
   ) {
     return this.svc.indexRequests(id, replace);
+  }
+
+  @Patch(':collectionId/requests/:requestId')
+  async updateRequestCritical(
+    @Param('collectionId') collectionId: string,
+    @Param('requestId') requestId: string,
+    @Body() body: UpdateRequestDto,
+  ) {
+    return this.svc.updateRequestCritical(collectionId, requestId, body.isCritical);
   }
 }

--- a/server/src/collections/collections.service.ts
+++ b/server/src/collections/collections.service.ts
@@ -211,4 +211,17 @@ export class CollectionsService {
 
     return { ...col, requests };
   }
+
+  async updateRequestCritical(collectionId: string, requestId: string, isCritical: boolean) {
+    const req = await this.prisma.collectionRequest.findUnique({ where: { id: requestId } });
+    if (!req || req.collectionId !== collectionId) {
+      throw new BadRequestException('request not found in collection');
+    }
+    const updated = await this.prisma.collectionRequest.update({
+      where: { id: requestId },
+      data: { isCritical },
+      select: { id: true, isCritical: true },
+    });
+    return updated;
+  }
 }

--- a/server/src/collections/dto/update-request.dto.ts
+++ b/server/src/collections/dto/update-request.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class UpdateRequestDto {
+  @IsBoolean()
+  isCritical!: boolean;
+}

--- a/server/src/runs/dto/list-assertions.dto.ts
+++ b/server/src/runs/dto/list-assertions.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class ListAssertionsDto {
+  @IsOptional() @IsInt() @Min(1) @Max(200)
+  limit?: number = 50;
+
+  @IsOptional() @IsInt() @Min(0)
+  offset?: number = 0;
+
+  @IsOptional() @IsString()
+  stepId?: string;
+}

--- a/server/src/runs/dto/list-run-steps.dto.ts
+++ b/server/src/runs/dto/list-run-steps.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class ListRunStepsDto {
+  @IsOptional() @IsInt() @Min(1) @Max(100)
+  limit?: number = 20;
+
+  @IsOptional() @IsInt() @Min(0)
+  offset?: number = 0;
+
+  @IsOptional() @IsString()
+  requestId?: string;
+}

--- a/server/src/runs/runs.controller.ts
+++ b/server/src/runs/runs.controller.ts
@@ -2,6 +2,8 @@ import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { RunsService } from './runs.service';
 import { CreateRunDto } from './dto/create-run.dto';
 import { ListRunsQueryDto } from './dto/list-runs.dto';
+import { ListRunStepsDto } from './dto/list-run-steps.dto';
+import { ListAssertionsDto } from './dto/list-assertions.dto';
 
 @Controller()
 export class RunsController {
@@ -23,13 +25,13 @@ export class RunsController {
   }
 
   @Get('api/runs/:runId/steps')
-  async steps(@Param('runId') runId: string) {
-    return this.svc.listSteps(runId);
+  async steps(@Param('runId') runId: string, @Query() q: ListRunStepsDto) {
+    return this.svc.listSteps(runId, q);
   }
 
   @Get('api/runs/:runId/assertions')
-  async assertions(@Param('runId') runId: string, @Query('stepId') stepId?: string) {
-    return this.svc.listAssertions(runId, stepId);
+  async assertions(@Param('runId') runId: string, @Query() q: ListAssertionsDto) {
+    return this.svc.listAssertions(runId, q);
   }
 
   @Get('api/runs')

--- a/server/test/runs-cancel-timeout.e2e-spec.ts
+++ b/server/test/runs-cancel-timeout.e2e-spec.ts
@@ -163,8 +163,8 @@ describe('Cancel & Timeout (e2e)', () => {
     expect(finished.status).toBe('success');
 
     const steps = await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).expect(200);
-    expect(steps.body.length).toBe(3);
-    for (const s of steps.body) {
+    expect(steps.body.total).toBe(3);
+    for (const s of steps.body.items) {
       expect(s.requestId).toBeTruthy();
       expect(s.request?.path).toMatch(/Slow (A|B|C)$/);
     }

--- a/server/test/runs-newman.e2e-spec.ts
+++ b/server/test/runs-newman.e2e-spec.ts
@@ -160,8 +160,8 @@ describe('Newman Runner (e2e)', () => {
     const steps = await request(app.getHttpServer())
       .get(`/api/runs/${runId}/steps`)
       .expect(200);
-    expect(steps.body.length).toBe(3);
-    steps.body.forEach((s: any) => {
+    expect(steps.body.total).toBe(3);
+    steps.body.items.forEach((s: any) => {
       expect(['success'].includes(s.status)).toBe(true);
       expect([200, 201]).toContain(s.httpStatus);
     });
@@ -170,8 +170,8 @@ describe('Newman Runner (e2e)', () => {
     const assertions = await request(app.getHttpServer())
       .get(`/api/runs/${runId}/assertions`)
       .expect(200);
-    expect(assertions.body.length).toBeGreaterThanOrEqual(3);
-    const names = assertions.body.map((a: any) => a.name);
+    expect(assertions.body.total).toBeGreaterThanOrEqual(3);
+    const names = assertions.body.items.map((a: any) => a.name);
     expect(names).toEqual(expect.arrayContaining(['status 200', 'status 201']));
   });
 });

--- a/server/test/runs-sse-pagination-health.e2e-spec.ts
+++ b/server/test/runs-sse-pagination-health.e2e-spec.ts
@@ -1,0 +1,261 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { AppModule } from '../src/app.module';
+import request from 'supertest';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { EventSource } from 'eventsource';
+import multipart from '@fastify/multipart';
+
+// ----- Helpers -----
+function startMockServer(delayMs = 50): Promise<{ server: http.Server, baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const respond = (code: number, body: any) => {
+        setTimeout(() => {
+          res.statusCode = code;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(body));
+        }, delayMs);
+      };
+      if (req.method === 'GET' && req.url === '/users') return respond(200, { ok: true, users: [1,2,3] });
+      if (req.method === 'GET' && req.url === '/users/1') return respond(200, { ok: true, id: 1 });
+      if (req.method === 'POST' && req.url === '/orders') {
+        let buf = ''; req.on('data', c => buf += c); req.on('end', () => respond(201, { ok: true, orderId: 42 }));
+        return;
+      }
+      // endpoint to keep failing at 200 while test expects 201 (for health weighting test)
+      if (req.method === 'GET' && req.url === '/bad') return respond(200, { ok: true });
+      res.statusCode = 404; res.end(JSON.stringify({ ok: false }));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function makeSSECollection() {
+  return {
+    info: { name: 'SSE Demo', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+    item: [
+      { name: 'Users', item: [
+        {
+          name: 'List Users',
+          request: { method: 'GET', url: '{{baseUrl}}/users' },
+          event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+            "pm.test('status 200', () => pm.response.to.have.status(200));",
+            "pm.test('has ok true', () => pm.expect(pm.response.json().ok).to.eql(true));",
+          ]}}]
+        },
+        {
+          name: 'Get User',
+          request: { method: 'GET', url: '{{baseUrl}}/users/1' },
+          event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+            "pm.test('status 200', () => pm.response.to.have.status(200));",
+          ]}}]
+        }
+      ]},
+      {
+        name: 'Orders',
+        item: [{
+          name: 'Create Order',
+          request: { method: 'POST', url: '{{baseUrl}}/orders', body: { mode: 'raw', raw: JSON.stringify({ item: 'X' }) }, header: [{key:'Content-Type', value:'application/json'}] },
+          event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+            "pm.test('status 201', () => pm.response.to.have.status(201));",
+          ]}}]
+        }]
+      }
+    ]
+  };
+}
+
+function makeEnv(baseUrl: string) {
+  return { name: 'sse-env', values: [{ key: 'baseUrl', value: baseUrl, type: 'text', enabled: true }] };
+}
+
+function makeHealthCollection() {
+  // two requests: OK (200 expect 200) and Bad (200 expect 201 => fail)
+  return {
+    info: { name: 'Health Demo', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+    item: [
+      { name: 'Group', item: [
+        {
+          name: 'OK',
+          request: { method: 'GET', url: '{{baseUrl}}/users' },
+          event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+            "pm.test('200', () => pm.response.to.have.status(200));"
+          ]}}]
+        },
+        {
+          name: 'Bad',
+          request: { method: 'GET', url: '{{baseUrl}}/bad' },
+          event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+            "pm.test('201', () => pm.response.to.have.status(201));" // will fail
+          ]}}]
+        }
+      ]}
+    ]
+  };
+}
+
+// ----- Tests -----
+describe('SSE + Pagination + Critical Health (e2e)', () => {
+  let app: NestFastifyApplication;
+  let mock: { server: http.Server, baseUrl: string };
+  let appUrl: string;
+
+  beforeAll(async () => {
+    mock = await startMockServer(30);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    await app.getHttpAdapter().getInstance().register(multipart as any);
+
+    // Listen on ephemeral port so EventSource can connect
+    await app.listen(0, '127.0.0.1');
+    const addr = (app.getHttpAdapter().getInstance().server.address() as AddressInfo);
+    appUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    mock.server.close();
+  });
+
+  it('streams rich SSE events and supports pagination', async () => {
+    const col = makeSSECollection();
+    const env = makeEnv(mock.baseUrl);
+
+    // upload + env
+    const up = await request(app.getHttpServer())
+      .post('/api/collections/upload')
+      .attach('collection', Buffer.from(JSON.stringify(col)), { filename: 'col.json', contentType: 'application/json' })
+      .attach('env', Buffer.from(JSON.stringify(env)), { filename: 'env.json', contentType: 'application/json' })
+      .expect(201);
+    const collectionId = up.body.collectionId;
+
+    // start run with small delay to allow SSE capture
+    const envId = (await request(app.getHttpServer()).get(`/api/collections/${collectionId}`)).body.envs[0].id;
+    const start = await request(app.getHttpServer())
+      .post(`/api/collections/${collectionId}/run`)
+      .send({ environmentId: envId, delayRequestMs: 10 })
+      .expect(201);
+    const runId = start.body.runId;
+
+    // SSE capture
+    const es = new EventSource(`${appUrl}/api/runs/${runId}/stream`);
+    const events: any = { started: false, steps: [], assertions: [], finished: null };
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('SSE timeout')), 8000);
+
+      es.addEventListener('run_started', () => { events.started = true; });
+      es.addEventListener('step_progress', (e: any) => {
+        const data = JSON.parse(e.data);
+        events.steps.push(data);
+      });
+      es.addEventListener('assertion_result', (e: any) => {
+        const data = JSON.parse(e.data);
+        events.assertions.push(data);
+      });
+      es.addEventListener('run_finished', (e: any) => {
+        clearTimeout(timer);
+        events.finished = JSON.parse(e.data);
+        es.close();
+        resolve();
+      });
+      es.onerror = (err: any) => { clearTimeout(timer); es.close(); reject(err); };
+    });
+
+    // Validate events
+    expect(events.started).toBe(true);
+    expect(events.steps.length).toBe(3);
+    for (const s of events.steps) {
+      expect(s.step.requestId).toBeTruthy();
+      expect(typeof s.step.httpStatus).toBe('number');
+      expect(typeof s.step.latencyMs === 'number' || s.step.latencyMs === null).toBe(true);
+      expect(typeof s.step.requestPath).toBe('string');
+    }
+    expect(events.assertions.length).toBeGreaterThanOrEqual(3);
+    expect(events.finished.summary.status).toBeDefined();
+
+    // Pagination: steps
+    const page1 = await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).query({ limit: 2, offset: 0 }).expect(200);
+    expect(page1.body.total).toBe(3);
+    expect(page1.body.items.length).toBe(2);
+
+    const page2 = await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).query({ limit: 2, offset: 2 }).expect(200);
+    expect(page2.body.items.length).toBe(1);
+
+    // Filter by requestId
+    const firstReqId = page1.body.items[0].requestId;
+    const filtered = await request(app.getHttpServer()).get(`/api/runs/${runId}/steps`).query({ requestId: firstReqId }).expect(200);
+    expect(filtered.body.total).toBe(1);
+
+    // Pagination: assertions
+    const assertsAll = await request(app.getHttpServer()).get(`/api/runs/${runId}/assertions`).expect(200);
+    expect(assertsAll.body.total).toBeGreaterThanOrEqual(3);
+    const stepId = page1.body.items[0].id;
+    const assertsStep = await request(app.getHttpServer()).get(`/api/runs/${runId}/assertions`).query({ stepId }).expect(200);
+    expect(assertsStep.body.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('applies critical-weighted health scoring', async () => {
+    const col = makeHealthCollection();
+    const env = makeEnv(mock.baseUrl);
+
+    // upload + index
+    const up = await request(app.getHttpServer())
+      .post('/api/collections/upload')
+      .attach('collection', Buffer.from(JSON.stringify(col)), { filename: 'col.json', contentType: 'application/json' })
+      .attach('env', Buffer.from(JSON.stringify(env)), { filename: 'env.json', contentType: 'application/json' })
+      .expect(201);
+    const collectionId = up.body.collectionId;
+    const envId = (await request(app.getHttpServer()).get(`/api/collections/${collectionId}`)).body.envs[0].id;
+
+    // run 1: before marking critical → should be DEGRADED (has a failure)
+    const r1 = await request(app.getHttpServer()).post(`/api/collections/${collectionId}/run`).send({ environmentId: envId }).expect(201);
+    const runId1 = r1.body.runId;
+
+    const finished1 = await (async () => {
+      const start = Date.now();
+      while (Date.now() - start < 8000) {
+        const res = await request(app.getHttpServer()).get(`/api/runs/${runId1}`).expect(200);
+        if (['success','partial','fail','timeout','error','cancelled'].includes(res.body.status)) return res.body;
+        await new Promise(r => setTimeout(r, 50));
+      }
+      throw new Error('run1 timeout');
+    })();
+    expect(finished1.status).toBe('partial');
+    expect(finished1.health).toBe('DEGRADED');
+
+    // mark "Bad" request as critical
+    const colDetail = await request(app.getHttpServer()).get(`/api/collections/${collectionId}`).query({ withRequests: 'true' }).expect(200);
+    const badReq = colDetail.body.requests.find((r: any) => r.path.endsWith('/Bad'));
+    expect(badReq).toBeTruthy();
+
+    await request(app.getHttpServer())
+      .patch(`/api/collections/${collectionId}/requests/${badReq.id}`)
+      .send({ isCritical: true })
+      .expect(200);
+
+    // run 2: now critical failure ⇒ UNHEALTHY
+    const r2 = await request(app.getHttpServer()).post(`/api/collections/${collectionId}/run`).send({ environmentId: envId }).expect(201);
+    const runId2 = r2.body.runId;
+
+    const finished2 = await (async () => {
+      const start = Date.now();
+      while (Date.now() - start < 8000) {
+        const res = await request(app.getHttpServer()).get(`/api/runs/${runId2}`).expect(200);
+        if (['success','partial','fail','timeout','error','cancelled'].includes(res.body.status)) return res.body;
+        await new Promise(r => setTimeout(r, 50));
+      }
+      throw new Error('run2 timeout');
+    })();
+
+    expect(finished2.status).toBe('partial');
+    expect(finished2.failedRequests).toBeGreaterThanOrEqual(1);
+    expect(finished2.health).toBe('UNHEALTHY');
+  });
+});


### PR DESCRIPTION
## Summary
- include request path info in step progress SSE and assertion error details
- paginate run steps and assertions with filtering
- track critical requests to weight final health status
- allow toggling collection request criticality
- add e2e coverage for SSE streaming, pagination, and health weighting

## Testing
- `pnpm pretest:e2e`
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68ab3ae677c48326b0339d3eddc1682c