### PR TITLE
fix: prefix API requests with /api

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,1 +1,2 @@
+# Base URL for the backend (do not include /api)
 NEXT_PUBLIC_API_BASE_URL=http://localhost:4000

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,9 +13,10 @@ async function request<T>(path: string, init?: RequestInit, timeoutMs = 15000): 
       reject(Object.assign(new Error('Request timeout'), { status: 408 }));
     }, timeoutMs);
   });
+  const prefixed = path.startsWith('/api') || path.startsWith('/health') ? path : `/api${path}`;
   try {
     const res = (await Promise.race([
-      fetch(`${base}${path}`, {
+      fetch(`${base}${prefixed}`, {
         ...init,
         headers: { 'content-type': 'application/json', ...(init?.headers || {}) },
         signal: controller.signal,


### PR DESCRIPTION
## Summary
- automatically prefix non-health requests with `/api`
- document API base URL without `/api`

## Testing
- `pnpm --filter ./web lint`
- `pnpm --filter ./web test:unit`
- `pnpm --filter ./web test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ab461d77ec83269e97a2c76dba0b99