### PR TITLE
feat(web): add collections list and upload

### DIFF
--- a/web/app/collections/page.tsx
+++ b/web/app/collections/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCollectionsList } from '@/features/collections/queries';
+import { CollectionsTable } from '@/components/collections/CollectionsTable';
+import { Pagination } from '@/components/collections/Pagination';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { UploadCollectionDialog } from '@/components/collections/UploadCollectionDialog';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+
+export default function CollectionsPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const initialQ = params.get('q') || '';
+  const initialPage = parseInt(params.get('page') || '1', 10);
+  const [q, setQ] = useState(initialQ);
+  const debouncedQ = useDebouncedValue(q, 400);
+  const page = isNaN(initialPage) ? 1 : initialPage;
+
+  const { data, isLoading, isError } = useCollectionsList(debouncedQ, page, 10);
+  const [open, setOpen] = useState(false);
+
+  const onSearchChange = (v: string) => {
+    setQ(v);
+    const sp = new URLSearchParams(params.toString());
+    sp.set('q', v);
+    sp.set('page', '1');
+    router.push(`/collections?${sp.toString()}`);
+  };
+
+  const total = data?.total ?? 0;
+  const limit = data?.limit ?? 10;
+  const items = data?.items ?? [];
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Collections</h1>
+        <Button onClick={() => setOpen(true)} aria-haspopup="dialog">Upload Collection</Button>
+      </div>
+      <div className="flex items-center gap-3">
+        <Input placeholder="Search collections…" value={q} onChange={(e) => onSearchChange(e.target.value)} />
+      </div>
+      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load collections.</div>}
+      {isLoading ? (
+        <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+      ) : (
+        <>
+          <CollectionsTable items={items} />
+          <Pagination total={total} limit={limit} />
+        </>
+      )}
+      <UploadCollectionDialog open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/web/e2e/collections.spec.ts
+++ b/web/e2e/collections.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('upload collection + env and see the new row', async ({ page }) => {
+  await page.goto('/collections');
+
+  await page.getByRole('button', { name: 'Upload Collection' }).click();
+
+  const colPath = path.resolve(__dirname, '../fixtures/postman/simple.collection.json');
+  const envPath = path.resolve(__dirname, '../fixtures/postman/dev.env.json');
+  await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+  await page.locator('input[type="file"][name="env"]').setInputFiles(envPath);
+
+  await page.getByRole('button', { name: 'Upload', exact: true }).click();
+
+  await expect(page.getByText('Collection uploaded successfully.')).toBeVisible({ timeout: 5000 });
+
+  await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
+
+  await page.getByPlaceholder('Search collections…').fill('Web FE Test Collection');
+  await page.waitForTimeout(500);
+  await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible();
+});

--- a/web/fixtures/postman/dev.env.json
+++ b/web/fixtures/postman/dev.env.json
@@ -1,0 +1,4 @@
+{
+  "name": "dev-env",
+  "values": [{ "key": "baseUrl", "value": "https://example.com", "type": "text", "enabled": true }]
+}

--- a/web/fixtures/postman/simple.collection.json
+++ b/web/fixtures/postman/simple.collection.json
@@ -1,0 +1,14 @@
+{
+  "info": {
+    "name": "Web FE Test Collection",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Users",
+      "item": [
+        { "name": "List Users", "request": { "method": "GET", "url": "https://example.com/users" } }
+      ]
+    }
+  ]
+}

--- a/web/src/components/collections/CollectionsTable.tsx
+++ b/web/src/components/collections/CollectionsTable.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import type { CollectionListItem } from '@/features/collections/types';
+
+export function CollectionsTable({ items }: { items: CollectionListItem[] }) {
+  if (!items?.length) {
+    return <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">No collections yet. Use “Upload Collection”.</div>;
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/40">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr className="text-left">
+            <th className="p-3">Name</th>
+            <th className="p-3">Version</th>
+            <th className="p-3">Created</th>
+            <th className="p-3">Envs</th>
+            <th className="p-3">Requests</th>
+            <th className="p-3">Runs</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((c) => (
+            <tr key={c.id} className="border-t border-border/40 hover:bg-muted/40">
+              <td className="p-3">
+                <Link href={`/collections/${c.id}`} className="text-primary hover:underline">{c.name}</Link>
+              </td>
+              <td className="p-3">{c.version ?? '-'}</td>
+              <td className="p-3">{new Date(c.createdAt).toLocaleString()}</td>
+              <td className="p-3">{c._count.envs}</td>
+              <td className="p-3">{c._count.requests}</td>
+              <td className="p-3">{c._count.runs}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/collections/Pagination.tsx
+++ b/web/src/components/collections/Pagination.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/components/ui/Button';
+
+export function Pagination({ total, limit }: { total: number; limit: number }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const page = Math.max(1, parseInt(params.get('page') || '1', 10));
+  const pages = Math.max(1, Math.ceil(total / limit));
+  const q = params.get('q') || '';
+
+  const go = (p: number) => {
+    const search = new URLSearchParams(params.toString());
+    search.set('page', String(p));
+    router.push(`/collections?${search.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center justify-between text-sm py-2">
+      <div>Page {page} / {pages} {q ? `(filtered)` : ''}</div>
+      <div className="flex gap-2">
+        <Button variant="ghost" disabled={page <= 1} onClick={() => go(page - 1)}>Prev</Button>
+        <Button variant="ghost" disabled={page >= pages} onClick={() => go(page + 1)}>Next</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/collections/UploadCollectionDialog.tsx
+++ b/web/src/components/collections/UploadCollectionDialog.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+import { useUploadCollection } from '@/features/collections/queries';
+import { useToast } from '@/components/ui/Toast';
+import { Spinner } from '@/components/ui/Spinner';
+
+export function UploadCollectionDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
+  const [colFile, setColFile] = useState<File | null>(null);
+  const [envFile, setEnvFile] = useState<File | null>(null);
+  const { toast } = useToast();
+  const { mutateAsync, isPending } = useUploadCollection();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!colFile) return;
+    try {
+      await mutateAsync({ collection: colFile, env: envFile || undefined });
+      toast({ title: 'Uploaded', description: 'Collection uploaded successfully.' });
+      formRef.current?.reset();
+      setColFile(null);
+      setEnvFile(null);
+      onOpenChange(false);
+    } catch (err: any) {
+      toast({ title: 'Upload failed', description: err?.message || 'Unknown error' });
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={() => onOpenChange(false)} title="Upload Postman Collection">
+      <form ref={formRef} onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="collection">Collection JSON *</label>
+          <input
+            id="collection"
+            name="collection"
+            type="file"
+            accept="application/json,.json"
+            required
+            onChange={(e) => setColFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm file:mr-3 file:rounded file:border file:border-border/50 file:px-3 file:py-1.5 file:bg-muted"
+          />
+          <p className="mt-1 text-xs opacity-70">Upload a Postman v2.x collection JSON.</p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="env">Environment JSON (optional)</label>
+          <input
+            id="env"
+            name="env"
+            type="file"
+            accept="application/json,.json"
+            onChange={(e) => setEnvFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm file:mr-3 file:rounded file:border file:border-border/50 file:px-3 file:py-1.5 file:bg-muted"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="submit" disabled={!colFile || isPending}>
+            {isPending ? <span className="flex items-center gap-2"><Spinner/> Uploading…</span> : 'Upload'}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/web/src/components/ui/Dialog.tsx
+++ b/web/src/components/ui/Dialog.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+export function Dialog({
+  open, onClose, children, title,
+}: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode }) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose(); }
+    if (open) document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div className={twMerge('w-full max-w-lg rounded-lg border border-border/50 bg-bg p-4 dark:bg-zinc-900')}>
+          {title && <div className="mb-2 text-lg font-medium">{title}</div>}
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { InputHTMLAttributes, forwardRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className, ...props }, ref,
+) {
+  return (
+    <input
+      ref={ref}
+      className={twMerge('h-9 w-full rounded-md border border-border/50 bg-bg px-3 text-sm outline-none focus:ring-2 focus:ring-primary/40 dark:bg-zinc-900', className)}
+      {...props}
+    />
+  );
+});

--- a/web/src/components/ui/Spinner.tsx
+++ b/web/src/components/ui/Spinner.tsx
@@ -1,0 +1,3 @@
+export function Spinner() {
+  return <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" aria-label="Loading" />;
+}

--- a/web/src/features/collections/queries.ts
+++ b/web/src/features/collections/queries.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { CollectionListResponse, UploadResponse } from './types';
+
+export function useCollectionsList(q: string, page: number, limit = 10) {
+  const offset = (Math.max(1, page) - 1) * limit;
+  return useQuery({
+    queryKey: ['collections', { q, page, limit }],
+    queryFn: () => {
+      const qs = new URLSearchParams();
+      qs.set('limit', String(limit));
+      qs.set('offset', String(offset));
+      if (q) qs.set('q', q);
+      return api.get<CollectionListResponse>(`/api/collections?${qs.toString()}`);
+    },
+    keepPreviousData: true,
+    staleTime: 5000,
+  });
+}
+
+export function useUploadCollection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (files: { collection: File; env?: File }) => {
+      const fd = new FormData();
+      fd.append('collection', files.collection);
+      if (files.env) fd.append('env', files.env);
+      return api.postMultipart<UploadResponse>('/api/collections/upload', fd);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['collections'] });
+    },
+  });
+}

--- a/web/src/features/collections/types.ts
+++ b/web/src/features/collections/types.ts
@@ -1,0 +1,17 @@
+export type CollectionListItem = {
+  id: string;
+  name: string;
+  version?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  _count: { envs: number; requests: number; runs: number };
+};
+
+export type CollectionListResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  items: CollectionListItem[];
+};
+
+export type UploadResponse = { collectionId: string };

--- a/web/src/hooks/useDebouncedValue.ts
+++ b/web/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs = 400) {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delayMs);
+    return () => clearTimeout(t);
+  }, [value, delayMs]);
+  return v;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -40,10 +40,48 @@ async function request<T>(path: string, init?: RequestInit, timeoutMs = 15000): 
   }
 }
 
+// multipart request helper (no explicit content-type)
+async function requestMultipart<T>(path: string, form: FormData, timeoutMs = 60000): Promise<T> {
+  const controller = new AbortController();
+  let id: NodeJS.Timeout;
+  const timeout = new Promise<never>((_, reject) => {
+    id = setTimeout(() => {
+      controller.abort();
+      reject(Object.assign(new Error('Request timeout'), { status: 408 }));
+    }, timeoutMs);
+  });
+  const prefixed = path.startsWith('/api') || path.startsWith('/health') ? path : `/api${path}`;
+  try {
+    const res = (await Promise.race([
+      fetch(`${base}${prefixed}`, {
+        method: 'POST',
+        body: form,
+        signal: controller.signal,
+        cache: 'no-store',
+      }),
+      timeout,
+    ])) as Response;
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : null;
+    if (!res.ok) {
+      const parsed = errorZ.safeParse(data);
+      const message = parsed.success ? parsed.data.message : res.statusText;
+      throw Object.assign(
+        new Error(typeof message === 'string' ? message : JSON.stringify(message)),
+        { status: res.status, data },
+      );
+    }
+    return data as T;
+  } finally {
+    clearTimeout(id!);
+  }
+}
+
 export const api = {
   get: <T>(path: string, timeoutMs?: number) => request<T>(path, { method: 'GET' }, timeoutMs),
   post: <T>(path: string, body?: unknown, timeoutMs?: number) =>
     request<T>(path, { method: 'POST', body: JSON.stringify(body ?? {}) }, timeoutMs),
   patch: <T>(path: string, body?: unknown, timeoutMs?: number) =>
     request<T>(path, { method: 'PATCH', body: JSON.stringify(body ?? {}) }, timeoutMs),
+  postMultipart: <T>(path: string, form: FormData, timeoutMs?: number) => requestMultipart<T>(path, form, timeoutMs),
 };

--- a/web/test/api.multipart.test.tsx
+++ b/web/test/api.multipart.test.tsx
@@ -1,0 +1,44 @@
+import { api } from '@/lib/api';
+
+describe('api.postMultipart', () => {
+  const realFetch = global.fetch as any;
+
+  afterEach(() => { global.fetch = realFetch; });
+
+  it('does not set content-type and returns JSON', async () => {
+    const fd = new FormData();
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ collectionId: 'col_123' }),
+    });
+
+    const resp = await api.postMultipart<{ collectionId: string }>(
+      '/api/collections/upload',
+      fd,
+    );
+    expect(resp.collectionId).toBe('col_123');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toMatch(/\/api\/collections\/upload$/);
+    const init = call[1];
+    expect(init.headers).toBeUndefined();
+    expect(init.body).toBe(fd);
+  });
+
+  it('bubbles server errors', async () => {
+    const fd = new FormData();
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () =>
+        JSON.stringify({ statusCode: 400, message: 'invalid Postman collection schema' }),
+    });
+    await expect(api.postMultipart('/api/collections/upload', fd)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add multipart helper to API client
- add collections list, search, upload, and pagination UI
- cover upload with unit and e2e tests

## Testing
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: expect(locator).toBeVisible() due to upload toast not appearing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab51a67e448326b0302931621d477e