### PR TITLE
Parse list collection query params explicitly

### DIFF
--- a/server/src/collections/collections.controller.ts
+++ b/server/src/collections/collections.controller.ts
@@ -12,7 +12,6 @@ import {
 } from '@nestjs/common';
 import { CollectionsService } from './collections.service';
 import { FastifyRequest } from 'fastify';
-import { ListCollectionsQueryDto } from './dto/list-collections.dto';
 import type { Multipart } from '@fastify/multipart';
 import { UpdateRequestDto } from './dto/update-request.dto';
 
@@ -63,8 +62,14 @@ export class CollectionsController {
   }
 
   @Get()
-  async list(@Query() q: ListCollectionsQueryDto) {
-    return this.svc.list(q.limit, q.offset, q.q);
+  async list(
+    @Query('limit') limitStr?: string,
+    @Query('offset') offsetStr?: string,
+    @Query('q') q?: string,
+  ) {
+    const limit = limitStr ? parseInt(limitStr, 10) : 20;
+    const offset = offsetStr ? parseInt(offsetStr, 10) : 0;
+    return this.svc.list(limit, offset, q);
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- parse `limit` and `offset` query params manually in collections controller to ensure numeric values

## Testing
- `pnpm --filter server lint` *(fails: Unexpected any, no-empty, etc.)*
- `pnpm --filter server test:e2e` *(fails: Module ts-jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5659deb88326a79ea8984e4017e3