### PR TITLE
feat: collection detail view

### DIFF
--- a/web/app/collections/[id]/loading.tsx
+++ b/web/app/collections/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="p-6 text-sm opacity-75">Loading…</div>;
+}

--- a/web/app/collections/[id]/page.tsx
+++ b/web/app/collections/[id]/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useState, useMemo } from 'react';
+import { useCollectionDetail } from '@/features/collections/queries';
+import { Input } from '@/components/ui/Input';
+import { RequestsTree } from '@/components/collections/RequestsTree';
+import { EnvsTable } from '@/components/collections/EnvsTable';
+import { Button } from '@/components/ui/Button';
+
+function useTab() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const tab = params.get('tab') || 'requests';
+  const setTab = (t: string) => {
+    const sp = new URLSearchParams(params.toString());
+    sp.set('tab', t);
+    router.replace(`?${sp.toString()}`);
+  };
+  return { tab, setTab };
+}
+
+export default function CollectionDetailPage({ params }: { params: { id: string } }) {
+  const id = params.id;
+  const { tab, setTab } = useTab();
+  const [filter, setFilter] = useState('');
+  const withRequests = tab === 'requests';
+
+  const { data, isLoading, isError } = useCollectionDetail(id, withRequests);
+
+  const header = useMemo(() => {
+    if (!data) return null;
+    return (
+      <div className="rounded border border-border/40 p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">{data.name}</h1>
+            <div className="text-sm opacity-70">
+              Version: {data.version ?? '-'} · Created: {new Date(data.createdAt).toLocaleString()} · Updated: {new Date(data.updatedAt).toLocaleString()}
+            </div>
+          </div>
+          <Link href="/collections" className="text-sm text-primary hover:underline">← Back to Collections</Link>
+        </div>
+      </div>
+    );
+  }, [data]);
+
+  return (
+    <div className="p-6 space-y-4">
+      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load collection.</div>}
+      {!isError && header}
+
+      {/* Tabs */}
+      <div className="border-b border-border/40 flex items-center gap-2">
+        {['requests','environments','history'].map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-2 text-sm -mb-px border-b-2 ${tab === t ? 'border-primary text-primary' : 'border-transparent opacity-70 hover:opacity-100'}`}
+            aria-current={tab === t ? 'page' : undefined}
+          >
+            {t[0].toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {isLoading && <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>}
+      {!isLoading && data && (
+        <>
+          {tab === 'requests' && (
+            <>
+              <div className="flex items-center gap-3">
+                <Input placeholder="Filter by name or path…" value={filter} onChange={(e) => setFilter(e.target.value)} />
+                <div className="text-sm opacity-70">Total indexed: {data._count.requests}</div>
+              </div>
+              <RequestsTree collectionId={id} requests={data.requests || []} filter={filter} />
+            </>
+          )}
+
+          {tab === 'environments' && (
+            <EnvsTable envs={data.envs} />
+          )}
+
+          {tab === 'history' && (
+            <div className="rounded border border-border/40 p-4 text-sm opacity-75">
+              History view coming soon (FE‑5). Use the Runs page meanwhile.
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/e2e/collection-detail.spec.ts
+++ b/web/e2e/collection-detail.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('navigates to detail and toggles critical flag', async ({ page }) => {
+  // Ensure a collection exists (upload if needed)
+  await page.goto('/collections');
+
+  const hasRow = await page.getByRole('link', { name: 'Web FE Test Collection' }).count();
+  if (!hasRow) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Go to detail
+  await page.getByRole('link', { name: 'Web FE Test Collection' }).click();
+  await expect(page.getByRole('heading', { name: 'Web FE Test Collection' })).toBeVisible();
+
+  // Requests tab is default; the FE‑1 fixture has one request "List Users"
+  // Mark it critical
+  const toggleBtn = page.getByRole('button', { name: /Mark critical|Unmark critical/ });
+  await toggleBtn.click();
+
+  // After optimistic update, badge should appear
+  await expect(page.getByText('CRITICAL')).toBeVisible();
+
+  // Reload to confirm persistence
+  await page.reload();
+  await expect(page.getByText('CRITICAL')).toBeVisible();
+
+  // Unmark to leave the system clean
+  await page.getByRole('button', { name: /Unmark critical/ }).click();
+  await expect(page.getByText('CRITICAL')).toHaveCount(0);
+});

--- a/web/src/components/collections/EnvsTable.tsx
+++ b/web/src/components/collections/EnvsTable.tsx
@@ -1,0 +1,25 @@
+'use client';
+import type { CollectionEnv } from '@/features/collections/types';
+
+export function EnvsTable({ envs }: { envs: CollectionEnv[] }) {
+  if (!envs?.length) return <div className="rounded border border-border/40 p-3 text-sm opacity-75">No environments.</div>;
+  return (
+    <div className="overflow-x-auto rounded border border-border/40">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr><th className="p-2 text-left">Name</th><th className="p-2 text-left">Default</th><th className="p-2 text-left">File</th><th className="p-2 text-left">Created</th></tr>
+        </thead>
+        <tbody>
+          {envs.map(e => (
+            <tr key={e.id} className="border-t border-border/40">
+              <td className="p-2">{e.name}</td>
+              <td className="p-2">{e.isDefault ? 'Yes' : 'No'}</td>
+              <td className="p-2 truncate max-w-[320px]"><code className="opacity-80">{e.fileUri}</code></td>
+              <td className="p-2">{new Date(e.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/collections/MethodBadge.tsx
+++ b/web/src/components/collections/MethodBadge.tsx
@@ -1,0 +1,11 @@
+'use client';
+export function MethodBadge({ m }: { m: string }) {
+  const color =
+    m === 'GET' ? 'bg-emerald-500' :
+    m === 'POST' ? 'bg-blue-500' :
+    m === 'PUT' ? 'bg-yellow-500' :
+    m === 'PATCH' ? 'bg-amber-500' :
+    m === 'DELETE' ? 'bg-red-500' :
+    'bg-zinc-500';
+  return <span className={`inline-block rounded px-1.5 py-0.5 text-xs text-white ${color}`}>{m}</span>;
+}

--- a/web/src/components/collections/RequestsTree.tsx
+++ b/web/src/components/collections/RequestsTree.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { buildRequestsTree, TreeNode } from '@/features/collections/tree';
+import type { RequestItem } from '@/features/collections/types';
+import { MethodBadge } from './MethodBadge';
+import { Button } from '@/components/ui/Button';
+import { useToggleCritical } from '@/features/collections/queries';
+
+export function RequestsTree({
+  collectionId,
+  requests,
+  filter,
+}: {
+  collectionId: string;
+  requests: RequestItem[];
+  filter: string;
+}) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const toggleCritical = useToggleCritical(collectionId);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return requests;
+    return requests.filter(r => r.name.toLowerCase().includes(q) || r.path.toLowerCase().includes(q));
+  }, [requests, filter]);
+
+  const tree = useMemo<TreeNode[]>(() => buildRequestsTree(filtered), [filtered]);
+
+  const expandAll = () => {
+    const next: Record<string, boolean> = {};
+    const walk = (nodes: TreeNode[]) => nodes.forEach(n => {
+      if (n.type === 'folder') { next[n.key] = true; walk(n.children); }
+    });
+    walk(tree);
+    setOpen(next);
+  };
+  const collapseAll = () => setOpen({});
+
+  const Folder = ({ node }: { node: Extract<TreeNode, { type: 'folder' }> }) => {
+    const isOpen = !!open[node.key];
+    return (
+      <div className="ml-2">
+        <div className="flex items-center gap-2 py-1 cursor-pointer select-none" onClick={() => setOpen({ ...open, [node.key]: !isOpen })}>
+          <span className="text-xs">{isOpen ? '▾' : '▸'}</span>
+          <span className="font-medium">{node.name}</span>
+        </div>
+        {isOpen && (
+          <div className="ml-4 border-l border-border/30">
+            {node.children.map(c => c.type === 'folder'
+              ? <Folder key={c.key} node={c} />
+              : <RequestRow key={c.key} node={c} />
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const RequestRow = ({ node }: { node: Extract<TreeNode, { type: 'request' }> }) => {
+    const isCritical = node.isCritical;
+    const busy = toggleCritical.isPending;
+
+    return (
+      <div className="flex items-center justify-between gap-3 py-1 pl-3 pr-2 hover:bg-muted/40 rounded">
+        <div className="flex items-center gap-2">
+          <MethodBadge m={node.method} />
+          <div className="text-sm">{node.name}</div>
+          {isCritical && <span className="text-[10px] rounded bg-red-600 text-white px-1.5 py-0.5">CRITICAL</span>}
+          <div className="text-xs opacity-60 font-mono">/{node.path}</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            disabled={busy}
+            onClick={() => toggleCritical.mutate({ requestId: node.id, isCritical: !isCritical })}
+            aria-label={isCritical ? 'Unmark critical' : 'Mark critical'}
+            title={isCritical ? 'Unmark critical' : 'Mark critical'}
+          >
+            {isCritical ? 'Unmark critical' : 'Mark critical'}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm opacity-70">{filtered.length} request(s)</div>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={expandAll}>Expand all</Button>
+          <Button variant="ghost" onClick={collapseAll}>Collapse all</Button>
+        </div>
+      </div>
+      <div className="rounded border border-border/40 p-2">
+        {tree.length === 0 ? (
+          <div className="p-4 text-sm opacity-70">No requests match your filter.</div>
+        ) : (
+          tree.map(n => n.type === 'folder'
+            ? <Folder key={n.key} node={n} />
+            : <RequestRow key={n.key} node={n} />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/collections/queries.ts
+++ b/web/src/features/collections/queries.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
-import type { CollectionListResponse, UploadResponse } from './types';
+import type { CollectionDetail, CollectionListResponse, UploadResponse } from './types';
 
 export function useCollectionsList(q: string, page: number, limit = 10) {
   const offset = (Math.max(1, page) - 1) * limit;
@@ -31,6 +31,45 @@ export function useUploadCollection() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['collections'] });
+    },
+  });
+}
+
+export function useCollectionDetail(id: string, withRequests: boolean) {
+  return useQuery({
+    queryKey: ['collection', id, { withRequests }],
+    queryFn: () => api.get<CollectionDetail>(`/api/collections/${id}${withRequests ? '?withRequests=true' : ''}`),
+    staleTime: 5_000,
+  });
+}
+
+export function useToggleCritical(collectionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (p: { requestId: string; isCritical: boolean }) => {
+      return api.patch<{ id: string; isCritical: boolean }>(
+        `/api/collections/${collectionId}/requests/${p.requestId}`,
+        { isCritical: p.isCritical },
+      );
+    },
+    onMutate: async (p) => {
+      await qc.cancelQueries({ queryKey: ['collection', collectionId] });
+      const key = ['collection', collectionId, { withRequests: true }];
+      const prev = qc.getQueryData<CollectionDetail>(key);
+      if (prev?.requests) {
+        const next: CollectionDetail = {
+          ...prev,
+          requests: prev.requests.map(r => r.id === p.requestId ? { ...r, isCritical: p.isCritical } : r),
+        };
+        qc.setQueryData(key, next);
+      }
+      return { prev };
+    },
+    onError: (_err, _p, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['collection', collectionId, { withRequests: true }], ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['collection', collectionId], exact: false });
     },
   });
 }

--- a/web/src/features/collections/tree.ts
+++ b/web/src/features/collections/tree.ts
@@ -1,0 +1,47 @@
+import type { RequestItem } from './types';
+
+export type TreeNode =
+  | { type: 'folder'; name: string; key: string; children: TreeNode[] }
+  | { type: 'request'; key: string; name: string; path: string; method: RequestItem['method']; isCritical: boolean; id: string };
+
+export function buildRequestsTree(requests: RequestItem[]): TreeNode[] {
+  const root: Record<string, any> = {};
+  for (const r of requests) {
+    const parts = r.path.split('/').filter(Boolean);
+    const keyParts: string[] = [];
+    let cursor = root;
+    for (let i = 0; i < parts.length; i++) {
+      keyParts.push(parts[i]);
+      const k = keyParts.join('/');
+      const isLeaf = i === parts.length - 1;
+      if (isLeaf) {
+        (cursor.__items ||= []).push({
+          type: 'request',
+          key: k,
+          name: parts[i],
+          path: r.path,
+          method: r.method,
+          isCritical: r.isCritical,
+          id: r.id,
+        });
+      } else {
+        cursor[parts[i]] ||= { __children: {}, __key: k, __name: parts[i] };
+        cursor = cursor[parts[i]].__children;
+      }
+    }
+  }
+  function toNodes(node: any): TreeNode[] {
+    const folders: TreeNode[] = Object.keys(node)
+      .filter(k => !k.startsWith('__'))
+      .sort((a, b) => a.localeCompare(b))
+      .map(k => ({
+        type: 'folder' as const,
+        name: node[k].__name,
+        key: node[k].__key,
+        children: toNodes(node[k].__children),
+      }));
+    const reqs: TreeNode[] = (node.__items || []).sort((a: any, b: any) => a.name.localeCompare(b.name));
+    return [...folders, ...reqs];
+  }
+  return toNodes(root);
+}

--- a/web/src/features/collections/types.ts
+++ b/web/src/features/collections/types.ts
@@ -15,3 +15,33 @@ export type CollectionListResponse = {
 };
 
 export type UploadResponse = { collectionId: string };
+
+export type CollectionEnv = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  fileUri: string;
+  createdAt: string;
+};
+
+export type RequestItem = {
+  id: string;
+  name: string;
+  method: 'GET'|'POST'|'PUT'|'PATCH'|'DELETE'|'HEAD'|'OPTIONS'|'TRACE';
+  url: string;
+  path: string; // e.g., "Users/List Users"
+  isCritical: boolean;
+};
+
+export type CollectionDetail = {
+  id: string;
+  name: string;
+  version?: string | null;
+  description?: string | null;
+  fileUri: string;
+  createdAt: string;
+  updatedAt: string;
+  envs: CollectionEnv[];
+  _count: { requests: number; runs: number };
+  requests?: RequestItem[]; // present when withRequests=true
+};

--- a/web/test/tree.builder.test.ts
+++ b/web/test/tree.builder.test.ts
@@ -1,0 +1,16 @@
+import { buildRequestsTree } from '@/features/collections/tree';
+import type { RequestItem } from '@/features/collections/types';
+
+test('builds nested tree grouped by path segments', () => {
+  const reqs: RequestItem[] = [
+    { id: '1', name: 'List Users', method: 'GET', url: '', path: 'Users/List Users', isCritical: false },
+    { id: '2', name: 'Get User', method: 'GET', url: '', path: 'Users/Get User', isCritical: false },
+    { id: '3', name: 'Create Order', method: 'POST', url: '', path: 'Orders/Create Order', isCritical: false },
+  ];
+  const tree = buildRequestsTree(reqs);
+  expect(tree.length).toBe(2);
+  const users = tree.find(n => n.type === 'folder' && n.name === 'Users')!;
+  expect(users && users.type === 'folder' && users.children.length).toBe(2);
+  const orders = tree.find(n => n.type === 'folder' && n.name === 'Orders')!;
+  expect(orders && orders.type === 'folder' && orders.children.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- implement collection detail view with requests tree and environments list
- add React Query hooks and utilities for request tree and critical toggle
- add unit and e2e tests for tree building and critical toggling

## Testing
- `pnpm -C web test:unit`
- `pnpm -C web dev` *(fails: no, passes? we started and terminated; we show log yes? the dev server started)*
- `pnpm -C web test:e2e` *(fails: Collection uploaded successfully toast not visible)*


------
https://chatgpt.com/codex/tasks/task_e_68ab5b0a97008326ad59f73465b981d1