### PR TITLE
feat: add run launcher and run page

### DIFF
--- a/web/app/collections/[id]/page.tsx
+++ b/web/app/collections/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/Input';
 import { RequestsTree } from '@/components/collections/RequestsTree';
 import { EnvsTable } from '@/components/collections/EnvsTable';
 import { Button } from '@/components/ui/Button';
+import { RunDialog } from '@/components/runs/RunDialog';
 
 function useTab() {
   const params = useSearchParams();
@@ -25,6 +26,7 @@ export default function CollectionDetailPage({ params }: { params: { id: string 
   const id = params.id;
   const { tab, setTab } = useTab();
   const [filter, setFilter] = useState('');
+  const [runOpen, setRunOpen] = useState(false);
   const withRequests = tab === 'requests';
 
   const { data, isLoading, isError } = useCollectionDetail(id, withRequests);
@@ -40,7 +42,15 @@ export default function CollectionDetailPage({ params }: { params: { id: string 
               Version: {data.version ?? '-'} · Created: {new Date(data.createdAt).toLocaleString()} · Updated: {new Date(data.updatedAt).toLocaleString()}
             </div>
           </div>
-          <Link href="/collections" className="text-sm text-primary hover:underline">← Back to Collections</Link>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setRunOpen(true)}
+              className="px-3 py-2 text-sm rounded-md bg-primary text-white hover:opacity-90"
+            >
+              Run collection
+            </button>
+            <Link href="/collections" className="text-sm text-primary hover:underline">← Back to Collections</Link>
+          </div>
         </div>
       </div>
     );
@@ -89,6 +99,14 @@ export default function CollectionDetailPage({ params }: { params: { id: string 
             </div>
           )}
         </>
+      )}
+      {data && (
+        <RunDialog
+          open={runOpen}
+          onOpenChange={setRunOpen}
+          collectionId={id}
+          envs={data.envs}
+        />
       )}
     </div>
   );

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+import { useRun } from '@/features/runs/queries';
+import { RunStatusBadge } from '@/components/runs/RunStatusBadge';
+
+export default function RunPage({ params }: { params: { runId: string } }) {
+  const runId = params.runId;
+  const { data, isLoading, isError } = useRun(runId);
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Run <span className="font-mono text-base">#{runId.slice(0, 8)}</span></h1>
+        <Link href="/runs" className="text-sm text-primary hover:underline">← Runs</Link>
+      </div>
+
+      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load run.</div>}
+      {isLoading && <div className="rounded border border-border/40 p-4 text-sm opacity-75">Loading…</div>}
+
+      {data && (
+        <div className="rounded border border-border/40 p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            <RunStatusBadge status={data.status} />
+            <div className="text-sm opacity-70">Health: <span className="font-mono">{data.health ?? '-'}</span></div>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+            <div>Created: <span className="font-mono">{new Date(data.createdAt).toLocaleString()}</span></div>
+            <div>Started: <span className="font-mono">{data.startedAt ? new Date(data.startedAt).toLocaleString() : '-'}</span></div>
+            <div>Ended: <span className="font-mono">{data.endedAt ? new Date(data.endedAt).toLocaleString() : '-'}</span></div>
+            <div>Total: <span className="font-mono">{data.totalRequests ?? 0}</span></div>
+            <div>Success: <span className="font-mono">{data.successRequests ?? 0}</span></div>
+            <div>Failed: <span className="font-mono">{data.failedRequests ?? 0}</span></div>
+            <div>P95 (ms): <span className="font-mono">{data.p95Ms ?? 0}</span></div>
+          </div>
+          {data.errorMsg && <div className="text-sm text-red-600">Error: {data.errorMsg}</div>}
+          <div className="text-xs opacity-70">This is a minimal view. The live console with step stream arrives in FE‑4.</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/e2e/run-launcher.spec.ts
+++ b/web/e2e/run-launcher.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('from collection detail → open dialog → start run → redirect to run page', async ({ page }) => {
+  // Ensure we have a collection; reuse FE-1 fixture if needed
+  await page.goto('/collections');
+  const exists = await page.getByRole('link', { name: 'Web FE Test Collection' }).count();
+  if (!exists) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Go to detail
+  await page.getByRole('link', { name: 'Web FE Test Collection' }).click();
+  await expect(page.getByRole('heading', { name: 'Web FE Test Collection' })).toBeVisible();
+
+  // Open Run dialog and start
+  await page.getByRole('button', { name: 'Run collection' }).click();
+  // Fill a tiny delay and maxDuration to complete quickly
+  const delay = page.locator('input[type="number"]').nth(1);
+  await delay.fill('10');
+  const maxDur = page.getByPlaceholder('(optional)');
+  await maxDur.fill('800');
+
+  await page.getByRole('button', { name: 'Start Run' }).click();
+
+  // Should redirect to /runs/[runId]
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // The run page shows status chip and basic fields
+  await expect(page.getByText(/Run #/)).toBeVisible();
+  await expect(page.getByText(/Status|Health|Total|P95|Created/)).toBeVisible({ timeout: 5000 });
+
+  // Wait for the page to show any terminal or running status (depends on your backend)
+  await expect(page.locator('span').filter({ hasText: /(queued|running|success|partial|timeout|error|cancelled)/ }))
+    .toBeVisible({ timeout: 15000 });
+});

--- a/web/src/components/runs/RunDialog.tsx
+++ b/web/src/components/runs/RunDialog.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { useCreateRun } from '@/features/runs/queries';
+import type { CollectionEnv } from '@/features/collections/types';
+import { useRouter } from 'next/navigation';
+import { useToast } from '@/components/ui/Toast';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  collectionId: string;
+  envs: CollectionEnv[];
+};
+
+function parseIntOrUndefined(v: string, min = 0) {
+  if (v === '' || v == null) return undefined;
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < min) return undefined;
+  return Math.floor(n);
+}
+
+export function RunDialog({ open, onOpenChange, collectionId, envs }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const createRun = useCreateRun(collectionId);
+
+  const [environmentId, setEnvironmentId] = useState<string>('');
+  const [timeoutRequestMs, setTimeoutRequestMs] = useState<string>('0');
+  const [delayRequestMs, setDelayRequestMs] = useState<string>('0');
+  const [maxDurationMs, setMaxDurationMs] = useState<string>(''); // optional
+  const [bail, setBail] = useState<boolean>(false);
+  const [insecure, setInsecure] = useState<boolean>(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const body: any = {};
+    const t = parseIntOrUndefined(timeoutRequestMs, 0);
+    const d = parseIntOrUndefined(delayRequestMs, 0);
+    const m = parseIntOrUndefined(maxDurationMs, 1);
+    if (environmentId) body.environmentId = environmentId;
+    if (typeof t === 'number') body.timeoutRequestMs = t;
+    if (typeof d === 'number') body.delayRequestMs = d;
+    if (typeof m === 'number') body.maxDurationMs = m;
+    if (bail) body.bail = true;
+    if (insecure) body.insecure = true;
+
+    try {
+      const res = await createRun.mutateAsync(body);
+      onOpenChange(false);
+      router.push(`/runs/${res.runId}`);
+    } catch (err: any) {
+      toast({ title: 'Failed to start run', description: err?.message || 'Unknown error' });
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={() => onOpenChange(false)} title="Run collection">
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Environment</label>
+          <select
+            className="h-9 w-full rounded-md border border-border/50 bg-bg px-3 text-sm dark:bg-zinc-900"
+            value={environmentId}
+            onChange={(e) => setEnvironmentId(e.target.value)}
+          >
+            <option value="">(None)</option>
+            {envs.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.name}{e.isDefault ? ' (default)' : ''}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs opacity-70">Optional. Use the default environment if applicable.</p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">Per-request timeout (ms)</label>
+            <Input type="number" min={0} step={1} value={timeoutRequestMs} onChange={(e) => setTimeoutRequestMs(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Delay between requests (ms)</label>
+            <Input type="number" min={0} step={1} value={delayRequestMs} onChange={(e) => setDelayRequestMs(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Max run duration (ms)</label>
+            <Input type="number" min={1} step={1} placeholder="(optional)" value={maxDurationMs} onChange={(e) => setMaxDurationMs(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-6">
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={bail} onChange={(e) => setBail(e.target.checked)} />
+            Bail on folder fail
+          </label>
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={insecure} onChange={(e) => setInsecure(e.target.checked)} />
+            Insecure (ignore TLS)
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="submit" disabled={createRun.isPending}>
+            {createRun.isPending ? 'Starting…' : 'Start Run'}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/web/src/components/runs/RunStatusBadge.tsx
+++ b/web/src/components/runs/RunStatusBadge.tsx
@@ -1,0 +1,13 @@
+'use client';
+import type { Run } from '@/features/runs/types';
+
+export function RunStatusBadge({ status }: { status: Run['status'] }) {
+  const color =
+    status === 'success' ? 'bg-emerald-500' :
+    status === 'running' ? 'bg-blue-500' :
+    status === 'queued' ? 'bg-zinc-500' :
+    status === 'partial' ? 'bg-amber-500' :
+    status === 'timeout' || status === 'error' || status === 'fail' ? 'bg-red-600' :
+    status === 'cancelled' ? 'bg-zinc-600' : 'bg-zinc-500';
+  return <span className={`inline-block rounded px-1.5 py-0.5 text-xs text-white ${color}`}>{status}</span>;
+}

--- a/web/src/features/runs/queries.ts
+++ b/web/src/features/runs/queries.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { CreateRunBody, CreateRunResponse, Run } from './types';
+
+export function useCreateRun(collectionId: string) {
+  return useMutation({
+    mutationFn: (body: CreateRunBody) =>
+      api.post<CreateRunResponse>(`/api/collections/${collectionId}/run`, body),
+  });
+}
+
+const TERMINAL: Run['status'][] = ['success','partial','fail','timeout','error','cancelled'];
+
+export function useRun(runId: string) {
+  return useQuery({
+    queryKey: ['run', runId],
+    queryFn: () => api.get<Run>(`/api/runs/${runId}`),
+    refetchInterval: (data) => {
+      if (!data) return 1000;
+      return TERMINAL.includes(data.status) ? false : 1000;
+    },
+  });
+}

--- a/web/src/features/runs/types.ts
+++ b/web/src/features/runs/types.ts
@@ -1,0 +1,32 @@
+export type RunStatus = 'queued'|'running'|'success'|'partial'|'fail'|'timeout'|'error'|'cancelled';
+export type HealthStatus = 'HEALTHY'|'DEGRADED'|'UNHEALTHY'|'UNKNOWN';
+
+export type Run = {
+  id: string;
+  collectionId: string;
+  environmentId?: string | null;
+  status: RunStatus;
+  health?: HealthStatus | null;
+  createdAt: string;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  durationMs?: number | null;
+  totalRequests?: number | null;
+  successRequests?: number | null;
+  failedRequests?: number | null;
+  p50Ms?: number | null;
+  p95Ms?: number | null;
+  p99Ms?: number | null;
+  errorMsg?: string | null;
+};
+
+export type CreateRunBody = Partial<{
+  environmentId: string;
+  timeoutRequestMs: number;
+  delayRequestMs: number;
+  bail: boolean;
+  insecure: boolean;
+  maxDurationMs: number;
+}>;
+
+export type CreateRunResponse = { runId: string };

--- a/web/test/run.options.normalize.test.ts
+++ b/web/test/run.options.normalize.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+
+// copy the tiny helper from RunDialog to test it in isolation
+function parseIntOrUndefined(v: string, min = 0) {
+  if (v === '' || v == null) return undefined;
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < min) return undefined;
+  return Math.floor(n);
+}
+
+describe('parseIntOrUndefined', () => {
+  it('parses valid numbers', () => {
+    expect(parseIntOrUndefined('0')).toBe(0);
+    expect(parseIntOrUndefined('15')).toBe(15);
+    expect(parseIntOrUndefined('15.7')).toBe(15);
+  });
+  it('enforces min', () => {
+    expect(parseIntOrUndefined('-1', 0)).toBeUndefined();
+    expect(parseIntOrUndefined('0', 1)).toBeUndefined();
+    expect(parseIntOrUndefined('1', 1)).toBe(1);
+  });
+  it('handles empty/invalid', () => {
+    // @ts-expect-error
+    expect(parseIntOrUndefined(undefined)).toBeUndefined();
+    expect(parseIntOrUndefined('')).toBeUndefined();
+    expect(parseIntOrUndefined('abc')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add runs types and react-query hooks
- implement run dialog to launch collection runs with options
- build minimal run status page and badge
- add tests for run options normalization and launch flow

## Testing
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: Upload button strict mode violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f3b624c8326b430e7a987c64cd4