### PR TITLE
feat: add live run console with SSE and fallback

### DIFF
--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -1,12 +1,45 @@
 'use client';
 
 import Link from 'next/link';
-import { useRun } from '@/features/runs/queries';
-import { RunStatusBadge } from '@/components/runs/RunStatusBadge';
+import { useRun, useCancelRun, useRunAssertions, useRunSteps } from '@/features/runs/queries';
+import { useRunStream } from '@/features/runs/stream';
+import { RunHeader } from '@/components/runs/RunHeader';
+import { RunTimeline } from '@/components/runs/RunTimeline';
+import { AssertionsPanel } from '@/components/runs/AssertionsPanel';
+import { useEffect, useMemo, useState } from 'react';
+
+const TERMINAL: string[] = ['success','partial','fail','timeout','error','cancelled'];
 
 export default function RunPage({ params }: { params: { runId: string } }) {
   const runId = params.runId;
-  const { data, isLoading, isError } = useRun(runId);
+
+  const { data: run } = useRun(runId);
+  const cancelMut = useCancelRun();
+
+  // Stream state
+  const { state, connected } = useRunStream(runId);
+  const finished = !!run && TERMINAL.includes(run.status);
+
+  // Fallback polling: if not connected (or once finished) fetch steps/assertions
+  const { data: polledSteps } = useRunSteps(runId, !connected || finished);
+
+  const steps = useMemo(
+    () => (connected ? state.steps : (polledSteps ?? [])),
+    [connected, state.steps, polledSteps]
+  );
+
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+
+  // Select first step automatically when it appears
+  useEffect(() => {
+    if (!selectedStepId && steps.length > 0) {
+      setSelectedStepId(steps[0].id);
+    }
+  }, [steps, selectedStepId]);
+
+  const { data: polledAssertions } = useRunAssertions(runId, selectedStepId, !connected || finished);
+  const liveAssertions = selectedStepId ? (state.assertionsByStep[selectedStepId] ?? []) : [];
+  const assertions = connected ? liveAssertions : (polledAssertions ?? []);
 
   return (
     <div className="p-6 space-y-4">
@@ -15,28 +48,27 @@ export default function RunPage({ params }: { params: { runId: string } }) {
         <Link href="/runs" className="text-sm text-primary hover:underline">← Runs</Link>
       </div>
 
-      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load run.</div>}
-      {isLoading && <div className="rounded border border-border/40 p-4 text-sm opacity-75">Loading…</div>}
+      <RunHeader
+        run={run}
+        connected={connected}
+        cancelling={cancelMut.isPending}
+        onCancel={() => cancelMut.mutate(runId)}
+      />
 
-      {data && (
-        <div className="rounded border border-border/40 p-4 space-y-3">
-          <div className="flex items-center gap-3">
-            <RunStatusBadge status={data.status} />
-            <div className="text-sm opacity-70">Health: <span className="font-mono">{data.health ?? '-'}</span></div>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
-            <div>Created: <span className="font-mono">{new Date(data.createdAt).toLocaleString()}</span></div>
-            <div>Started: <span className="font-mono">{data.startedAt ? new Date(data.startedAt).toLocaleString() : '-'}</span></div>
-            <div>Ended: <span className="font-mono">{data.endedAt ? new Date(data.endedAt).toLocaleString() : '-'}</span></div>
-            <div>Total: <span className="font-mono">{data.totalRequests ?? 0}</span></div>
-            <div>Success: <span className="font-mono">{data.successRequests ?? 0}</span></div>
-            <div>Failed: <span className="font-mono">{data.failedRequests ?? 0}</span></div>
-            <div>P95 (ms): <span className="font-mono">{data.p95Ms ?? 0}</span></div>
-          </div>
-          {data.errorMsg && <div className="text-sm text-red-600">Error: {data.errorMsg}</div>}
-          <div className="text-xs opacity-70">This is a minimal view. The live console with step stream arrives in FE‑4.</div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <h2 className="text-sm font-medium mb-2">Timeline</h2>
+          <RunTimeline
+            steps={steps}
+            selectedStepId={selectedStepId}
+            onSelect={setSelectedStepId}
+          />
         </div>
-      )}
+        <div>
+          <h2 className="text-sm font-medium mb-2">Assertions</h2>
+          <AssertionsPanel assertions={assertions} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/e2e/collection-detail.spec.ts
+++ b/web/e2e/collection-detail.spec.ts
@@ -10,7 +10,7 @@ test('navigates to detail and toggles critical flag', async ({ page }) => {
     await page.getByRole('button', { name: 'Upload Collection' }).click();
     const colPath = path.resolve(__dirname, '../fixtures/postman/simple.collection.json');
     await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
-    await page.getByRole('button', { name: 'Upload' }).click();
+    await page.getByRole('button', { name: 'Upload', exact: true }).click();
     await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
   }
 

--- a/web/e2e/run-console.sse.spec.ts
+++ b/web/e2e/run-console.sse.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+function startMockServer(delay = 40) {
+  return new Promise<{ server: http.Server, baseUrl: string }>((resolve) => {
+    const server = http.createServer((req, res) => {
+      const respond = (code: number, body: any) => {
+        setTimeout(() => {
+          res.statusCode = code;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(body));
+        }, delay);
+      };
+      if (req.method === 'GET' && req.url === '/users') return respond(200, { ok: true, users: [1,2] });
+      if (req.method === 'GET' && req.url === '/users/1') return respond(200, { ok: true, id: 1 });
+      if (req.method === 'POST' && req.url === '/orders') {
+        let buf = ''; req.on('data', c => buf += c); req.on('end', () => respond(201, { ok: true, orderId: 42 }));
+        return;
+      }
+      res.statusCode = 404; res.end(JSON.stringify({ ok: false }));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function collectionFor(baseUrl: string) {
+  return {
+    info: { name: 'SSE Live Demo', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+    item: [
+      { name: 'Users', item: [
+        { name: 'List Users', request: { method: 'GET', url: '{{baseUrl}}/users' }, event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+          "pm.test('200', () => pm.response.to.have.status(200));"
+        ]}}]},
+        { name: 'Get User', request: { method: 'GET', url: '{{baseUrl}}/users/1' }, event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+          "pm.test('200', () => pm.response.to.have.status(200));"
+        ]}}]},
+      ]},
+      { name: 'Orders', item: [
+        { name: 'Create Order', request: { method: 'POST', url: '{{baseUrl}}/orders', header: [{key:'Content-Type', value:'application/json'}], body: { mode: 'raw', raw: JSON.stringify({item:'X'}) } }, event: [{ listen: 'test', script: { type: 'text/javascript', exec: [
+          "pm.test('201', () => pm.response.to.have.status(201));"
+        ]}}]},
+      ]},
+    ]
+  };
+}
+
+function envFor(baseUrl: string) {
+  return { name: 'sse-env', values: [{ key: 'baseUrl', value: baseUrl, type: 'text', enabled: true }] };
+}
+
+test('live SSE timeline and cancel', async ({ page }) => {
+  const mock = await startMockServer();
+
+  // Upload collection + env
+  await page.goto('/collections');
+  await page.getByRole('button', { name: 'Upload Collection' }).click();
+
+  // Upload dynamic files using FilePayloads
+  const colPayload = {
+    name: 'col.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(collectionFor(mock.baseUrl)), 'utf8'),
+  };
+  const envPayload = {
+    name: 'env.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(envFor(mock.baseUrl)), 'utf8'),
+  };
+
+  await page.locator('input[type="file"][name="collection"]').setInputFiles(colPayload);
+  await page.locator('input[type="file"][name="env"]').setInputFiles(envPayload);
+  await page.getByRole('button', { name: 'Upload', exact: true }).click();
+
+  // Navigate to detail
+  await page.getByRole('link', { name: 'SSE Live Demo' }).click();
+  await expect(page.getByRole('heading', { name: 'SSE Live Demo' })).toBeVisible();
+
+  // Start run (small delay for nicer streaming)
+  await page.getByRole('button', { name: 'Run collection' }).click();
+  await page.locator('input[type="number"]').nth(1).fill('10'); // delayRequestMs
+  await page.getByRole('button', { name: 'Start Run' }).click();
+
+  // Should redirect to /runs/[runId]
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // Timeline should progressively show steps (via SSE)
+  await expect(page.getByRole('heading', { name: 'Timeline' })).toBeVisible();
+  // wait for at least one streamed item
+  await expect(page.getByText(/List Users/)).toBeVisible({ timeout: 12000 });
+  // and eventually all three
+  await expect(page.getByText(/Create Order/)).toBeVisible({ timeout: 12000 });
+
+  // Assertions panel should show at least one passing assertion
+  await expect(page.getByText(/Assertions/)).toBeVisible();
+  await expect(page.getByText(/PASS|FAIL/)).toBeVisible({ timeout: 12000 });
+
+  // Launch a second run and cancel quickly to exercise the cancel path + fallback
+  await page.goto('/collections');
+  await page.getByRole('link', { name: 'SSE Live Demo' }).click();
+  await page.getByRole('button', { name: 'Run collection' }).click();
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+  // Cancel immediately
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  // Terminal state should be visible eventually
+  await expect(page.locator('span').filter({ hasText: /(cancelled|partial|success|timeout|error|fail)/ })).toBeVisible({ timeout: 15000 });
+
+  await new Promise<void>((res) => mock.server.close(() => res()));
+});

--- a/web/e2e/run-launcher.spec.ts
+++ b/web/e2e/run-launcher.spec.ts
@@ -9,7 +9,7 @@ test('from collection detail → open dialog → start run → redirect to run p
     await page.getByRole('button', { name: 'Upload Collection' }).click();
     const colPath = path.resolve(__dirname, '../fixtures/postman/simple.collection.json');
     await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
-    await page.getByRole('button', { name: 'Upload' }).click();
+    await page.getByRole('button', { name: 'Upload', exact: true }).click();
     await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
   }
 

--- a/web/src/components/runs/AssertionsPanel.tsx
+++ b/web/src/components/runs/AssertionsPanel.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { RunAssertionView } from '@/features/runs/types';
+
+export function AssertionsPanel({ assertions }: { assertions: RunAssertionView[] }) {
+  if (!assertions.length) {
+    return <div className="rounded border border-border/40 p-4 text-sm opacity-70">No assertions for this step.</div>;
+  }
+  return (
+    <div className="rounded border border-border/40">
+      <ul className="divide-y divide-border/40">
+        {assertions.map((a, i) => (
+          <li key={`${a.name}-${i}`} className="p-3">
+            <div className="flex items-center justify-between">
+              <div className="text-sm">{a.name}</div>
+              <span className={`text-xs rounded px-1.5 py-0.5 ${a.status === 'pass' ? 'bg-emerald-600 text-white' : 'bg-red-600 text-white'}`}>
+                {a.status.toUpperCase()}
+              </span>
+            </div>
+            {a.errorMsg && <div className="text-xs text-red-600 mt-1">{a.errorMsg}</div>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/runs/RunHeader.tsx
+++ b/web/src/components/runs/RunHeader.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { Run } from '@/features/runs/types';
+import { RunStatusBadge } from './RunStatusBadge';
+import { Button } from '@/components/ui/Button';
+
+export function RunHeader({
+  run,
+  onCancel,
+  cancelling,
+  connected,
+}: {
+  run: Run | undefined;
+  onCancel: () => void;
+  cancelling: boolean;
+  connected: boolean;
+}) {
+  return (
+    <div className="rounded border border-border/40 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <RunStatusBadge status={run?.status ?? 'queued'} />
+          <div className="text-sm opacity-70">
+            Health: <span className="font-mono">{run?.health ?? '-'}</span>
+          </div>
+          <div className={`text-xs rounded px-1.5 py-0.5 ${connected ? 'bg-emerald-600 text-white' : 'bg-zinc-600 text-white'}`}>
+            {connected ? 'LIVE' : 'DISCONNECTED'}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" onClick={onCancel} disabled={cancelling || !run || ['success','partial','fail','timeout','error','cancelled'].includes(run.status)}>
+            {cancelling ? 'Cancelling…' : 'Cancel'}
+          </Button>
+        </div>
+      </div>
+
+      {run && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+          <div>Created: <span className="font-mono">{new Date(run.createdAt).toLocaleString()}</span></div>
+          <div>Started: <span className="font-mono">{run.startedAt ? new Date(run.startedAt).toLocaleString() : '-'}</span></div>
+          <div>Ended: <span className="font-mono">{run.endedAt ? new Date(run.endedAt).toLocaleString() : '-'}</span></div>
+          <div>Total: <span className="font-mono">{run.totalRequests ?? 0}</span></div>
+          <div>Success: <span className="font-mono">{run.successRequests ?? 0}</span></div>
+          <div>Failed: <span className="font-mono">{run.failedRequests ?? 0}</span></div>
+          <div>P95 (ms): <span className="font-mono">{run.p95Ms ?? 0}</span></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/runs/RunTimeline.tsx
+++ b/web/src/components/runs/RunTimeline.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { RunStepView } from '@/features/runs/types';
+
+export function RunTimeline({
+  steps,
+  selectedStepId,
+  onSelect,
+}: {
+  steps: RunStepView[];
+  selectedStepId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (!steps.length) {
+    return <div className="rounded border border-border/40 p-4 text-sm opacity-70">No steps yet…</div>;
+  }
+  return (
+    <div className="rounded border border-border/40">
+      <ul className="max-h-[60vh] overflow-auto divide-y divide-border/40">
+        {steps.map((s) => {
+          const isSel = s.id === selectedStepId;
+          const statusColor = s.status === 'success' ? 'text-emerald-600' : 'text-red-600';
+          return (
+            <li
+              key={s.id}
+              className={`p-3 cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-muted/60' : ''}`}
+              onClick={() => onSelect(s.id)}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span className={`text-xs font-medium ${statusColor}`}>{s.status.toUpperCase()}</span>
+                  <span className="text-sm">{s.name}</span>
+                </div>
+                <div className="text-xs opacity-70">
+                  <span className="mr-2">{s.httpStatus ?? '-'}</span>
+                  <span className="mr-2">{s.latencyMs != null ? `${s.latencyMs}ms` : '-'}</span>
+                </div>
+              </div>
+              {s.requestPath && <div className="text-xs opacity-60 font-mono mt-1">/{s.requestPath}</div>}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/features/runs/queries.ts
+++ b/web/src/features/runs/queries.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
-import type { CreateRunBody, CreateRunResponse, Run } from './types';
+import type { CreateRunBody, CreateRunResponse, Run, RunAssertionView, RunStepView } from './types';
 
 export function useCreateRun(collectionId: string) {
   return useMutation({
@@ -21,5 +21,46 @@ export function useRun(runId: string) {
       if (!data) return 1000;
       return TERMINAL.includes(data.status) ? false : 1000;
     },
+  });
+}
+
+export function useRunSteps(runId: string, enabled: boolean) {
+  // fetch up to 2000 steps as a single page for fallback; adjust if you expect more
+  return useQuery({
+    queryKey: ['run-steps', runId],
+    queryFn: () => api.get<{ total: number; items: (RunStepView & { request: { path: string } | null })[] }>(`/api/runs/${runId}/steps?limit=2000&offset=0`),
+    enabled,
+    select: (res) =>
+      res.items.map((s) => ({
+        id: s.id,
+        name: s.name,
+        status: s.status as any,
+        httpStatus: s.httpStatus ?? null,
+        latencyMs: s.latencyMs ?? null,
+        requestId: s.requestId ?? null,
+        requestPath: s.request?.path ?? null,
+        orderIndex: s.orderIndex ?? null,
+      })) as RunStepView[],
+    staleTime: 1000,
+    refetchInterval: enabled ? 2000 : false,
+  });
+}
+
+export function useRunAssertions(runId: string, stepId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: ['run-assertions', runId, stepId],
+    queryFn: () => api.get<{ total: number; items: { id: string; runStepId: string; name: string; status: 'pass'|'fail'; errorMsg?: string | null }[] }>(
+      `/api/runs/${runId}/assertions${stepId ? `?stepId=${stepId}` : ''}`
+    ),
+    enabled,
+    select: (res) => res.items.map(i => ({ stepId: i.runStepId, name: i.name, status: i.status, errorMsg: i.errorMsg ?? null })),
+    staleTime: 1000,
+    refetchInterval: enabled ? 2000 : false,
+  });
+}
+
+export function useCancelRun() {
+  return useMutation({
+    mutationFn: (runId: string) => api.post<{ status: string }>(`/api/runs/${runId}/cancel`, {}),
   });
 }

--- a/web/src/features/runs/stream.ts
+++ b/web/src/features/runs/stream.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { Run, RunAssertionView, RunStepView } from './types';
+
+type StreamEvent =
+  | { type: 'run_started' }
+  | { type: 'step_progress'; step: RunStepView }
+  | { type: 'assertion_result'; stepId: string; assertion: Omit<RunAssertionView, 'stepId'> }
+  | { type: 'run_finished'; summary: Run };
+
+type State = {
+  steps: RunStepView[];
+  assertionsByStep: Record<string, RunAssertionView[]>;
+  finished: boolean;
+};
+
+type Action =
+  | { t: 'step'; step: RunStepView }
+  | { t: 'assertion'; stepId: string; assertion: RunAssertionView }
+  | { t: 'finish' }
+  | { t: 'reset' };
+
+export function consoleReducer(state: State, action: Action): State {
+  switch (action.t) {
+    case 'reset':
+      return { steps: [], assertionsByStep: {}, finished: false };
+    case 'step': {
+      // Update if already present, else push
+      const idx = state.steps.findIndex(s => s.id === action.step.id);
+      const steps = idx >= 0
+        ? Object.assign([...state.steps], { [idx]: { ...state.steps[idx], ...action.step } })
+        : [...state.steps, action.step];
+      // Keep order by orderIndex if provided, else by id insertion
+      steps.sort((a, b) => {
+        const ai = a.orderIndex ?? Number.MAX_SAFE_INTEGER;
+        const bi = b.orderIndex ?? Number.MAX_SAFE_INTEGER;
+        return ai - bi || a.id.localeCompare(b.id);
+      });
+      return { ...state, steps };
+    }
+    case 'assertion': {
+      const list = state.assertionsByStep[action.stepId] ?? [];
+      return {
+        ...state,
+        assertionsByStep: {
+          ...state.assertionsByStep,
+          [action.stepId]: [...list, action.assertion],
+        },
+      };
+    }
+    case 'finish':
+      return { ...state, finished: true };
+    default:
+      return state;
+  }
+}
+
+export function useRunStream(runId: string) {
+  const qc = useQueryClient();
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  const [state, dispatch] = useReducer(consoleReducer, { steps: [], assertionsByStep: {}, finished: false });
+
+  useEffect(() => {
+    dispatch({ t: 'reset' });
+    setError(null);
+    setConnected(false);
+
+    const url = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000'}/api/runs/${runId}/stream`;
+    const es = new EventSource(url, { withCredentials: false });
+    esRef.current = es;
+
+    es.addEventListener('run_started', () => setConnected(true));
+
+    es.addEventListener('step_progress', (e) => {
+      try {
+        const data = JSON.parse((e as MessageEvent).data);
+        const step = data.step as RunStepView;
+        dispatch({ t: 'step', step });
+      } catch (err) {}
+    });
+
+    es.addEventListener('assertion_result', (e) => {
+      try {
+        const data = JSON.parse((e as MessageEvent).data);
+        const stepId: string = data.stepId;
+        const a: RunAssertionView = { stepId, ...data.assertion };
+        dispatch({ t: 'assertion', stepId, assertion: a });
+      } catch (err) {}
+    });
+
+    es.addEventListener('run_finished', (e) => {
+      try {
+        const data = JSON.parse((e as MessageEvent).data);
+        // Push the summary into the react-query cache so useRun(...) sees terminal
+        qc.setQueryData(['run', runId], data.summary);
+      } catch {}
+      dispatch({ t: 'finish' });
+      setConnected(false);
+      // Close the stream
+      es.close();
+      esRef.current = null;
+    });
+
+    es.onerror = () => {
+      setError('stream-error');
+      setConnected(false);
+      // do not auto-close; let fallback kick in while keeping ES around for retry ideas (not implemented)
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [runId, qc]);
+
+  return { state, connected, error };
+}

--- a/web/src/features/runs/types.ts
+++ b/web/src/features/runs/types.ts
@@ -30,3 +30,24 @@ export type CreateRunBody = Partial<{
 }>;
 
 export type CreateRunResponse = { runId: string };
+
+export type StepStatus = 'success'|'fail';
+export type AssertionStatus = 'pass'|'fail';
+
+export type RunStepView = {
+  id: string;
+  name: string;
+  status: StepStatus;
+  httpStatus: number | null;
+  latencyMs: number | null;
+  requestId?: string | null;
+  requestPath?: string | null;
+  orderIndex?: number | null;
+};
+
+export type RunAssertionView = {
+  stepId: string;
+  name: string;
+  status: AssertionStatus;
+  errorMsg?: string | null;
+};

--- a/web/test/run.console.reducer.test.ts
+++ b/web/test/run.console.reducer.test.ts
@@ -1,0 +1,23 @@
+import { consoleReducer } from '@/features/runs/stream';
+import type { RunStepView, RunAssertionView } from '@/features/runs/types';
+
+test('console reducer appends and updates steps, records assertions, finishes', () => {
+  const s1: RunStepView = { id: 'a', name: 'A', status: 'success', httpStatus: 200, latencyMs: 12, requestPath: 'Users/A', orderIndex: 0 };
+  const s2: RunStepView = { id: 'b', name: 'B', status: 'success', httpStatus: 201, latencyMs: 20, requestPath: 'Users/B', orderIndex: 1 };
+
+  let st = consoleReducer({ steps: [], assertionsByStep: {}, finished: false }, { t: 'step', step: s1 });
+  st = consoleReducer(st, { t: 'step', step: s2 });
+  expect(st.steps.map(x => x.id)).toEqual(['a','b']);
+
+  // update step a with failure
+  const s1b: RunStepView = { ...s1, status: 'fail', httpStatus: 500 };
+  st = consoleReducer(st, { t: 'step', step: s1b });
+  expect(st.steps[0].status).toBe('fail');
+
+  const a: RunAssertionView = { stepId: 'a', name: 'should be 200', status: 'fail', errorMsg: 'got 500' };
+  st = consoleReducer(st, { t: 'assertion', stepId: 'a', assertion: a });
+  expect(st.assertionsByStep['a'].length).toBe(1);
+
+  st = consoleReducer(st, { t: 'finish' });
+  expect(st.finished).toBe(true);
+});


### PR DESCRIPTION
## Summary
- implement streaming console for runs with SSE and fallback polling
- display timeline, assertions, and cancel control
- add reducer tests and E2E for live steps

## Testing
- `pnpm -C web test:unit`
- `pnpm -C web test:e2e` *(fails: getByRole('link', { name: 'Web FE Test Collection' }) not visible)*

------
https://chatgpt.com/codex/tasks/task_e_68ab63dffcfc8326a512f48b245e8bbc