### PR TITLE
feat: add runs list with filters and tests

### DIFF
--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { useRunsList, useCollectionNameMap } from '@/features/runs/queries';
+import { RunsTable } from '@/components/runs/RunsTable';
+import { CollectionSelect } from '@/components/runs/CollectionSelect';
+import { RunsPagination } from '@/components/runs/RunsPagination';
+import { Input } from '@/components/ui/Input';
+
+const STATUSES = ['all','queued','running','success','partial','timeout','error','cancelled'] as const;
+
+export default function RunsPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const page = Math.max(1, parseInt(params.get('page') || '1', 10));
+  const status = (params.get('status') || 'all') as typeof STATUSES[number];
+  const collectionId = params.get('collectionId') || undefined;
+  const from = params.get('from') || ''; // client-only filter (current page)
+  const to = params.get('to') || '';
+
+  const { data, isLoading, isError } = useRunsList({ collectionId, status, page, limit: 10 });
+  const { data: nameMap } = useCollectionNameMap();
+
+  const setParam = (k: string, v?: string) => {
+    const sp = new URLSearchParams(params.toString());
+    if (v) sp.set(k, v); else sp.delete(k);
+    sp.set('page', '1'); // reset page on filter change
+    router.push(`/runs?${sp.toString()}`);
+  };
+
+  const filteredItems = useMemo(() => {
+    const items = data?.items ?? [];
+    if (!from && !to) return items;
+    const fromTs = from ? new Date(from).getTime() : -Infinity;
+    const toTs = to ? new Date(to).getTime() : Infinity;
+    return items.filter(i => {
+      const ts = new Date(i.createdAt).getTime();
+      return ts >= fromTs && ts <= toTs;
+    });
+  }, [data?.items, from, to]);
+
+  const collectionNameOf = (id: string) => nameMap?.get(id) || id.slice(0, 8);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Runs</h1>
+
+      <div className="rounded border border-border/40 p-3">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <div className="space-y-1">
+            <div className="text-xs opacity-70">Collection</div>
+            <CollectionSelect value={collectionId} onChange={(id) => setParam('collectionId', id)} />
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs opacity-70">Status</div>
+            <select
+              className="h-9 w-full rounded-md border border-border/50 bg-bg px-3 text-sm dark:bg-zinc-900"
+              value={status}
+              onChange={(e) => setParam('status', e.target.value)}
+            >
+              {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs opacity-70">From (client)</div>
+            <Input type="datetime-local" value={from} onChange={(e) => setParam('from', e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs opacity-70">To (client)</div>
+            <Input type="datetime-local" value={to} onChange={(e) => setParam('to', e.target.value)} />
+          </div>
+        </div>
+      </div>
+
+      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load runs.</div>}
+
+      {isLoading ? (
+        <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+      ) : (
+        <>
+          <RunsTable items={filteredItems} collectionNameOf={collectionNameOf} />
+          <RunsPagination total={data?.total ?? 0} limit={data?.limit ?? 10} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/e2e/runs-list.spec.ts
+++ b/web/e2e/runs-list.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+/** Ensures there is at least one run for a known collection; creates it if needed */
+async function ensureRunFor(page, name: string) {
+  await page.goto('/collections');
+  const exists = await page.getByRole('link', { name }).count();
+  if (!exists) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../..', 'fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Start one run (no env needed for the simple fixture; it calls example.com so it may end up partial)
+  await page.getByRole('link', { name }).click();
+  await expect(page.getByRole('heading', { name })).toBeVisible();
+  await page.getByRole('button', { name: 'Run collection' }).click();
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+}
+
+test('filters by collection and navigates to a run', async ({ page }) => {
+  const collName = 'Web FE Test Collection';
+  await ensureRunFor(page, collName);
+
+  // Go to runs
+  await page.goto('/runs');
+
+  // Open collection autocomplete and pick our collection
+  await page.getByPlaceholder(/Filter by collection/).click();
+  // If the selected label is shown, clear to show the menu
+  await page.getByPlaceholder(/Filter by collection|Selected:/).fill(collName.slice(0, 6));
+  await expect(page.getByText(collName)).toBeVisible();
+  await page.getByText(collName, { exact: true }).click();
+
+  // Table should have at least one row for that collection
+  const row = page.getByRole('link', { name: /^[a-z0-9]{8}$/ }); // run id short
+  await expect(row).toBeVisible({ timeout: 10000 });
+
+  // Click the first run id, it should navigate to the run console
+  await row.first().click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+  await expect(page.getByText(/Timeline|Assertions/)).toBeVisible();
+});

--- a/web/src/components/runs/CollectionSelect.tsx
+++ b/web/src/components/runs/CollectionSelect.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { useCollectionsLookup } from '@/features/runs/queries';
+import { Input } from '@/components/ui/Input';
+
+export function CollectionSelect({
+  value,
+  onChange,
+}: {
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+}) {
+  const [q, setQ] = useState('');
+  const { data } = useCollectionsLookup(q, 10);
+
+  // When a collection id is currently selected, show its name as read-only value at top of list
+  const selected = useMemo(() => data?.items.find(i => i.id === value), [data, value]);
+
+  // Debounce-like UX via built-in state; we already query on change above
+  useEffect(() => { /* no-op, just to hint controlled input */ }, [q]);
+
+  return (
+    <div className="relative">
+      <Input
+        placeholder={selected ? `Selected: ${selected.name} (type to change)` : 'Filter by collection…'}
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+      />
+      { (q || data) && (
+        <div className="absolute z-10 mt-1 w-full rounded border border-border/40 bg-bg dark:bg-zinc-900 text-sm max-h-64 overflow-auto">
+          <button
+            className={`w-full text-left px-3 py-2 hover:bg-muted ${!value ? 'font-medium' : ''}`}
+            onClick={() => { onChange(undefined); setQ(''); }}
+          >
+            (All collections)
+          </button>
+          {data?.items.map((c) => (
+            <button
+              key={c.id}
+              className={`w-full text-left px-3 py-2 hover:bg-muted ${c.id === value ? 'font-medium' : ''}`}
+              onClick={() => { onChange(c.id); setQ(''); }}
+            >
+              {c.name}
+            </button>
+          ))}
+          {!data?.items.length && q && <div className="px-3 py-2 opacity-70">No matches</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/runs/HealthBadge.tsx
+++ b/web/src/components/runs/HealthBadge.tsx
@@ -1,0 +1,12 @@
+'use client';
+import type { HealthStatus } from '@/features/runs/types';
+
+export function HealthBadge({ health }: { health: HealthStatus | null | undefined }) {
+  const label = health ?? 'UNKNOWN';
+  const cls =
+    label === 'HEALTHY' ? 'bg-emerald-600' :
+    label === 'DEGRADED' ? 'bg-amber-500' :
+    label === 'UNHEALTHY' ? 'bg-red-600' :
+    'bg-zinc-600';
+  return <span className={`inline-block rounded px-1.5 py-0.5 text-xs text-white ${cls}`}>{label}</span>;
+}

--- a/web/src/components/runs/RunsPagination.tsx
+++ b/web/src/components/runs/RunsPagination.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { Button } from '@/components/ui/Button';
+
+export function RunsPagination({ total, limit }: { total: number; limit: number }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const page = Math.max(1, parseInt(params.get('page') || '1', 10));
+  const pages = Math.max(1, Math.ceil(total / limit));
+
+  const go = (p: number) => {
+    const sp = new URLSearchParams(params.toString());
+    sp.set('page', String(p));
+    router.push(`${pathname}?${sp.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center justify-between text-sm py-2">
+      <div>Page {page} / {pages} { (params.get('collectionId') || params.get('status') || params.get('from') || params.get('to')) ? '(filtered)' : ''}</div>
+      <div className="flex gap-2">
+        <Button variant="ghost" disabled={page <= 1} onClick={() => go(page - 1)}>Prev</Button>
+        <Button variant="ghost" disabled={page >= pages} onClick={() => go(page + 1)}>Next</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/runs/RunsTable.tsx
+++ b/web/src/components/runs/RunsTable.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import type { RunListItem } from '@/features/runs/types';
+import { RunStatusBadge } from './RunStatusBadge';
+import { HealthBadge } from './HealthBadge';
+
+export function RunsTable({
+  items,
+  collectionNameOf,
+}: {
+  items: RunListItem[];
+  collectionNameOf: (id: string) => string;
+}) {
+  if (!items?.length) {
+    return <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">No runs found.</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/40">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr className="text-left">
+            <th className="p-3">Run</th>
+            <th className="p-3">Collection</th>
+            <th className="p-3">Status</th>
+            <th className="p-3">Health</th>
+            <th className="p-3">Created</th>
+            <th className="p-3">Duration</th>
+            <th className="p-3">P95 (ms)</th>
+            <th className="p-3">Failed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((r) => (
+            <tr key={r.id} className="border-t border-border/40 hover:bg-muted/40">
+              <td className="p-3">
+                <Link href={`/runs/${r.id}`} className="text-primary hover:underline font-mono">{r.id.slice(0, 8)}</Link>
+              </td>
+              <td className="p-3">
+                <Link href={`/collections/${r.collectionId}`} className="text-primary hover:underline">
+                  {collectionNameOf(r.collectionId)}
+                </Link>
+              </td>
+              <td className="p-3"><RunStatusBadge status={r.status} /></td>
+              <td className="p-3"><HealthBadge health={r.health ?? undefined} /></td>
+              <td className="p-3">{new Date(r.createdAt).toLocaleString()}</td>
+              <td className="p-3">{r.durationMs != null ? `${r.durationMs} ms` : '-'}</td>
+              <td className="p-3">{r.p95Ms ?? '-'}</td>
+              <td className="p-3">{r.failedRequests ?? 0}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/features/runs/types.ts
+++ b/web/src/features/runs/types.ts
@@ -51,3 +51,21 @@ export type RunAssertionView = {
   status: AssertionStatus;
   errorMsg?: string | null;
 };
+
+export type RunListItem = {
+  id: string;
+  collectionId: string;
+  status: RunStatus;
+  health?: HealthStatus | null;
+  createdAt: string;
+  durationMs?: number | null;
+  p95Ms?: number | null;
+  failedRequests?: number | null;
+};
+
+export type RunListResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  items: RunListItem[];
+};

--- a/web/test/health.badge.test.tsx
+++ b/web/test/health.badge.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { HealthBadge } from '@/components/runs/HealthBadge';
+
+test('renders correct label and class', () => {
+  const { rerender } = render(<HealthBadge health="HEALTHY" />);
+  expect(screen.getByText('HEALTHY')).toBeInTheDocument();
+
+  rerender(<HealthBadge health="DEGRADED" />);
+  expect(screen.getByText('DEGRADED')).toBeInTheDocument();
+
+  rerender(<HealthBadge health="UNHEALTHY" />);
+  expect(screen.getByText('UNHEALTHY')).toBeInTheDocument();
+
+  rerender(<HealthBadge health={null} />);
+  expect(screen.getByText('UNKNOWN')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add RunList types and hooks for run listing and collection lookup
- build /runs page with filterable, paginated table and badges
- test health badge mapping and runs list filtering

## Testing
- `pnpm -C web test:unit`
- `pnpm -C web test:e2e` *(fails: element not found during upload, likely backend server missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6000a75083268d6a94f37dee2941