### PR TITLE
feat: add collection health dashboard

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -3,22 +3,70 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { HealthCard } from '@/components/dashboard/HealthCard';
+import { useCollectionsOverview, useTopFailingRequests } from '@/features/dashboard/queries';
+import { CollectionHealthCard } from '@/components/dashboard/CollectionHealthCard';
+import { TopFailingRequests } from '@/components/dashboard/TopFailingRequests';
+import Link from 'next/link';
 
 export default function DashboardPage() {
-  const { data, isLoading, isError } = useQuery({
+  const health = useQuery({
     queryKey: ['health'],
     queryFn: () => api.get<{ status: string; time: string; env: string; uptimeMs: number }>('/health'),
     staleTime: 5_000,
   });
 
+  const { data: cols, isLoading, isError } = useCollectionsOverview(24);
+  const { data: failing } = useTopFailingRequests(7, 30);
+
+  const items = cols?.items ?? [];
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Dashboard</h1>
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+
+      {/* Row 1: Backend health + quick actions */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <HealthCard loading={isLoading} error={isError} data={data} />
-        {/* Placeholder cards for collections, runs, etc. (FE-1..6) */}
-        <div className="rounded-lg border p-4 border-border/40">Coming soon…</div>
+        <HealthCard loading={health.isLoading} error={!!health.isError} data={health.data} />
+        <div className="rounded-lg border p-4 border-border/40">
+          <div className="font-medium mb-2">Get started</div>
+          <ul className="list-disc list-inside text-sm opacity-80 space-y-1">
+            <li><Link href="/collections" className="text-primary hover:underline">Upload a Postman collection</Link></li>
+            <li>Open a collection and click <em>Run collection</em> to start a run.</li>
+            <li>Watch live progress in the <Link href="/runs" className="text-primary hover:underline">Run Console</Link>.</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Row 2: Collections grid */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <div className="font-medium">Collections</div>
+          <Link href="/collections" className="text-sm text-primary hover:underline">View all →</Link>
+        </div>
+
+        {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load collections.</div>}
+        {isLoading ? (
+          <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+        ) : items.length === 0 ? (
+          <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">
+            No collections yet. Go to <Link className="text-primary hover:underline" href="/collections">Collections</Link> to upload your first one.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {items.map((c) => <CollectionHealthCard key={c.id} c={c} />)}
+          </div>
+        )}
+      </div>
+
+      {/* Row 3: Top failing requests */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <div className="font-medium">Top failing requests (7d)</div>
+          <Link href="/runs" className="text-sm text-primary hover:underline">Browse runs →</Link>
+        </div>
+        <TopFailingRequests items={failing ?? []} emptyReason="No recent runs or failures found." />
       </div>
     </div>
   );
 }
+

--- a/web/e2e/dashboard-run-now.spec.ts
+++ b/web/e2e/dashboard-run-now.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('dashboard shows collection cards and Run now launches a run', async ({ page }) => {
+  // Ensure at least one collection exists
+  await page.goto('/collections');
+  const has = await page.getByRole('link', { name: 'Web FE Test Collection' }).count();
+  if (!has) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../..', 'fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Go to dashboard and see card
+  await page.goto('/dashboard');
+  const card = page.getByRole('link', { name: 'Web FE Test Collection' });
+  await expect(card).toBeVisible({ timeout: 10000 });
+
+  // Click Run now on that card → dialog → Start Run → redirect to /runs/[id]
+  // Find the nearest Run now button (assumes first card matches)
+  const runNow = page.getByRole('button', { name: 'Run now' }).first();
+  await runNow.click();
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // Basic console appears
+  await expect(page.getByText(/Timeline|Assertions/)).toBeVisible({ timeout: 10000 });
+});
+

--- a/web/src/components/dashboard/CollectionHealthCard.tsx
+++ b/web/src/components/dashboard/CollectionHealthCard.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { CollectionListItem } from '@/features/collections/types';
+import { useLatestRunForCollection, successRate } from '@/features/dashboard/queries';
+import { RunStatusBadge } from '@/components/runs/RunStatusBadge';
+import { HealthBadge } from '@/components/runs/HealthBadge';
+import { QuickRunButton } from '@/components/runs/QuickRunButton';
+import Link from 'next/link';
+
+export function CollectionHealthCard({ c }: { c: CollectionListItem }) {
+  const { data: run, isLoading } = useLatestRunForCollection(c.id);
+  const rate = successRate(run);
+
+  return (
+    <div className="rounded-lg border border-border/40 p-4 flex flex-col justify-between">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <Link href={`/collections/${c.id}`} className="text-base font-medium text-primary hover:underline">
+            {c.name}
+          </Link>
+          <div className="text-xs opacity-70">Version: {c.version ?? '-'} · Requests: {c._count.requests} · Runs: {c._count.runs}</div>
+        </div>
+        <QuickRunButton collectionId={c.id} />
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+        <div className="flex items-center gap-2">
+          <span className="opacity-70">Status:</span>
+          {isLoading ? <span className="text-xs opacity-60">Loading…</span> :
+            run ? <RunStatusBadge status={run.status} /> : <span className="text-xs opacity-60">No runs</span>}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="opacity-70">Health:</span>
+          {run ? <HealthBadge health={run.health ?? undefined} /> : <span className="text-xs opacity-60">-</span>}
+        </div>
+        <div><span className="opacity-70">P95:</span> <span className="font-mono">{run?.p95Ms ?? '-'}</span></div>
+        <div><span className="opacity-70">Success:</span> <span className="font-mono">{rate != null ? `${rate}%` : '-'}</span></div>
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/components/dashboard/TopFailingRequests.tsx
+++ b/web/src/components/dashboard/TopFailingRequests.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import type { FailingItem } from '@/features/dashboard/queries';
+
+export function TopFailingRequests({
+  items,
+  emptyReason,
+}: {
+  items: FailingItem[];
+  emptyReason?: string;
+}) {
+  if (!items.length) {
+    return (
+      <div className="rounded-lg border border-border/40 p-4 text-sm opacity-75">
+        {emptyReason || 'No failing requests in the selected window.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/40">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr className="text-left">
+            <th className="p-3">Request Path</th>
+            <th className="p-3">Fail Count</th>
+            <th className="p-3">Last Seen</th>
+            <th className="p-3">Sample Run</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it) => (
+            <tr key={it.key} className="border-t border-border/40">
+              <td className="p-3 font-mono">{it.path}</td>
+              <td className="p-3">{it.count}</td>
+              <td className="p-3">{new Date(it.lastSeen).toLocaleString()}</td>
+              <td className="p-3">
+                <Link href={`/runs/${it.sampleRunId}`} className="text-primary hover:underline font-mono">
+                  {it.sampleRunId.slice(0, 8)}
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/web/src/components/runs/QuickRunButton.tsx
+++ b/web/src/components/runs/QuickRunButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { RunDialog } from '@/components/runs/RunDialog';
+import { useCollectionDetail } from '@/features/collections/queries';
+
+export function QuickRunButton({ collectionId }: { collectionId: string }) {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useCollectionDetail(collectionId, false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} aria-haspopup="dialog">Run now</Button>
+      {open && (
+        <RunDialog
+          open={open}
+          onOpenChange={setOpen}
+          collectionId={collectionId}
+          envs={data?.envs ?? []}
+        />
+      )}
+    </>
+  );
+}
+

--- a/web/src/features/dashboard/queries.ts
+++ b/web/src/features/dashboard/queries.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { CollectionListItem, CollectionListResponse } from '@/features/collections/types';
+import type { Run, RunListResponse } from '@/features/runs/types';
+
+// Load collections (first N for the grid)
+export function useCollectionsOverview(limit = 24) {
+  return useQuery({
+    queryKey: ['dashboard', 'collections', limit],
+    queryFn: () => api.get<CollectionListResponse>(`/api/collections?limit=${limit}&offset=0`),
+    staleTime: 5_000,
+  });
+}
+
+// Fetch latest Run (full detail) for a collection (1 request to /runs? then 1 to /runs/:id)
+export function useLatestRunForCollection(collectionId: string) {
+  return useQuery({
+    queryKey: ['dashboard', 'latest-run', collectionId],
+    queryFn: async () => {
+      const list = await api.get<RunListResponse>(`/api/runs?collectionId=${collectionId}&limit=1&offset=0`);
+      if (!list.items.length) return null;
+      const runId = list.items[0].id;
+      const run = await api.get<Run>(`/api/runs/${runId}`);
+      return run;
+    },
+    staleTime: 5_000,
+  });
+}
+
+export type FailingItem = { key: string; path: string; count: number; lastSeen: string; sampleRunId: string };
+
+// Compute "Top failing requests (7d)" from recent runs & their steps
+export function useTopFailingRequests(days = 7, maxRuns = 30) {
+  return useQuery({
+    queryKey: ['dashboard', 'top-failing', days, maxRuns],
+    queryFn: async (): Promise<FailingItem[]> => {
+      const now = Date.now();
+      const fromTs = now - days * 24 * 60 * 60 * 1000;
+
+      const runsResp = await api.get<RunListResponse>(`/api/runs?limit=${maxRuns}&offset=0`);
+      const recent = runsResp.items
+        .filter(r => new Date(r.createdAt).getTime() >= fromTs)
+        // newest first
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+      if (!recent.length) return [];
+
+      const stepsLists = await Promise.all(
+        recent.map(r => api.get<{ total: number; items: { id: string; name: string; status: 'success'|'fail'; orderIndex?: number; requestId?: string | null; request?: { path: string } | null }[] }>(
+          `/api/runs/${r.id}/steps?limit=2000&offset=0`
+        ).then(s => ({ runId: r.id, createdAt: r.createdAt, steps: s.items })))
+      );
+
+      const agg = new Map<string, FailingItem>();
+      for (const { runId, createdAt, steps } of stepsLists) {
+        for (const s of steps) {
+          if (s.status === 'success') continue;
+          const path = s.request?.path || s.name || 'unknown';
+          const key = path;
+          const prev = agg.get(key);
+          if (!prev) {
+            agg.set(key, { key, path, count: 1, lastSeen: createdAt, sampleRunId: runId });
+          } else {
+            const newer = new Date(createdAt) > new Date(prev.lastSeen) ? createdAt : prev.lastSeen;
+            agg.set(key, { ...prev, count: prev.count + 1, lastSeen: newer });
+          }
+        }
+      }
+
+      return Array.from(agg.values())
+        .sort((a, b) => b.count - a.count || b.lastSeen.localeCompare(a.lastSeen))
+        .slice(0, 10);
+    },
+    staleTime: 30_000,
+  });
+}
+
+// Helper to compute success rate from a run
+export function successRate(run: Run | null): number | null {
+  if (!run || run.totalRequests == null || run.successRequests == null) return null;
+  if (run.totalRequests === 0) return 100;
+  return Math.round((run.successRequests / run.totalRequests) * 100);
+}
+

--- a/web/test/dashboard.success-rate.test.ts
+++ b/web/test/dashboard.success-rate.test.ts
@@ -1,0 +1,23 @@
+import { successRate } from '@/features/dashboard/queries';
+import type { Run } from '@/features/runs/types';
+
+const baseRun: Run = {
+  id: 'r',
+  collectionId: 'c',
+  status: 'success',
+  createdAt: new Date().toISOString(),
+  startedAt: null,
+  endedAt: null,
+};
+
+test('computes success rate', () => {
+  expect(successRate(null)).toBeNull();
+  expect(successRate({ ...baseRun, totalRequests: 0, successRequests: 0 } as any)).toBe(100);
+  expect(successRate({ ...baseRun, totalRequests: 10, successRequests: 7 } as any)).toBe(70);
+  expect(successRate({ ...baseRun, totalRequests: 3, successRequests: 3 } as any)).toBe(100);
+});
+
+test('returns null if missing fields', () => {
+  expect(successRate({ ...baseRun } as any)).toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- add dashboard queries for collections, latest run, and top failing requests
- show collection health cards, QuickRun button, and failing requests panel on dashboard
- add success rate helper unit test and e2e for dashboard run now

## Testing
- `pnpm i`
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: ENOENT fixtures and other dashboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac65ff93d08326aa6778383d309d93