### PR TITLE
feat: polish environments tab with preferred env actions

### DIFF
--- a/web/e2e/envs-preferred.spec.ts
+++ b/web/e2e/envs-preferred.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('set preferred env and RunDialog preselects it', async ({ page }) => {
+  // Ensure collection with env exists (use FE-1 fixtures)
+  await page.goto('/collections');
+  const hasRow = await page.getByRole('link', { name: 'Web FE Test Collection' }).count();
+  if (!hasRow) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../..', 'fixtures/postman/simple.collection.json');
+    const envPath = path.resolve(__dirname, '../..', 'fixtures/postman/dev.env.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.locator('input[type="file"][name="env"]').setInputFiles(envPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: 'Web FE Test Collection' })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Go detail → Environments tab
+  await page.getByRole('link', { name: 'Web FE Test Collection' }).click();
+  await expect(page.getByRole('heading', { name: 'Web FE Test Collection' })).toBeVisible();
+  await page.getByRole('button', { name: 'Environments' }).click();
+
+  // Set preferred
+  await page.getByRole('button', { name: /Set preferred|Preferred/ }).first().click(); // toggles for first env
+  // Preferred star should appear in table
+  await expect(page.getByText('★')).toBeVisible();
+
+  // Run with this env → Start Run → redirected
+  await page.getByRole('button', { name: 'Run' }).first().click();
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // Go back to collection and open header Run dialog; env should be preselected
+  await page.getByRole('link', { name: '← Runs' }).click(); // back to /runs
+  await page.getByRole('link', { name: '← Back to Collections' }).click().catch(() => {}); // or navigate directly:
+  await page.goto('/collections');
+  await page.getByRole('link', { name: 'Web FE Test Collection' }).click();
+
+  // Open header "Run collection"
+  await page.getByRole('button', { name: 'Run collection' }).click();
+
+  // Assert the selected option text includes the env name ("dev-env")
+  const selectedText = await page
+    .locator('select[aria-label="Environment"]')
+    .evaluate((el: HTMLSelectElement) => el.selectedOptions[0]?.textContent || '');
+  expect(selectedText.toLowerCase()).toContain('dev-env');
+});

--- a/web/src/components/collections/EnvsTable.tsx
+++ b/web/src/components/collections/EnvsTable.tsx
@@ -1,25 +1,131 @@
 'use client';
+import { useMemo, useState } from 'react';
 import type { CollectionEnv } from '@/features/collections/types';
+import { toAbsoluteUri, parsePostmanEnv, ParsedEnvVar } from '@/features/collections/envUtils';
+import { Button } from '@/components/ui/Button';
 
-export function EnvsTable({ envs }: { envs: CollectionEnv[] }) {
-  if (!envs?.length) return <div className="rounded border border-border/40 p-3 text-sm opacity-75">No environments.</div>;
+export function EnvsTable({
+  envs,
+  preferredEnvId,
+  onSetPreferred,
+  onRunWith,
+}: {
+  envs: CollectionEnv[];
+  preferredEnvId?: string;
+  onSetPreferred?: (envId: string) => void;
+  onRunWith?: (envId: string) => void;
+}) {
+  const [inspectId, setInspectId] = useState<string | null>(null);
+  const [vars, setVars] = useState<ParsedEnvVar[] | null>(null);
+  const envMap = useMemo(() => new Map(envs.map(e => [e.id, e])), [envs]);
+
+  async function openInspect(envId: string) {
+    setInspectId(envId);
+    setVars(null);
+    const env = envMap.get(envId);
+    if (!env) return;
+    const abs = toAbsoluteUri(env.fileUri);
+    if (!abs) return; // cannot preview
+    try {
+      const res = await fetch(abs, { cache: 'no-store' });
+      const json = await res.json();
+      setVars(parsePostmanEnv(json));
+    } catch {
+      setVars([]); // show "no vars"
+    }
+  }
+
+  async function copyVars() {
+    if (!vars || !vars.length) return;
+    const text = vars.filter(v => v.enabled).map(v => `${v.key}=${v.value}`).join('\n');
+    try { await navigator.clipboard.writeText(text); } catch {}
+  }
+
+  if (!envs?.length) {
+    return <div className="rounded border border-border/40 p-3 text-sm opacity-75">No environments.</div>;
+  }
   return (
-    <div className="overflow-x-auto rounded border border-border/40">
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50">
-          <tr><th className="p-2 text-left">Name</th><th className="p-2 text-left">Default</th><th className="p-2 text-left">File</th><th className="p-2 text-left">Created</th></tr>
-        </thead>
-        <tbody>
-          {envs.map(e => (
-            <tr key={e.id} className="border-t border-border/40">
-              <td className="p-2">{e.name}</td>
-              <td className="p-2">{e.isDefault ? 'Yes' : 'No'}</td>
-              <td className="p-2 truncate max-w-[320px]"><code className="opacity-80">{e.fileUri}</code></td>
-              <td className="p-2">{new Date(e.createdAt).toLocaleString()}</td>
+    <>
+      <div className="overflow-x-auto rounded border border-border/40">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2 text-left">Default</th>
+              <th className="p-2 text-left">Preferred</th>
+              <th className="p-2 text-left">File</th>
+              <th className="p-2 text-left">Created</th>
+              <th className="p-2 text-left">Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {envs.map(e => {
+              const abs = toAbsoluteUri(e.fileUri);
+              const isPreferred = e.id === preferredEnvId;
+              return (
+                <tr key={e.id} className="border-t border-border/40">
+                  <td className="p-2">{e.name}</td>
+                  <td className="p-2">{e.isDefault ? 'Yes' : 'No'}</td>
+                  <td className="p-2">{isPreferred ? '★' : ''}</td>
+                  <td className="p-2 truncate max-w-[280px]"><code className="opacity-80">{e.fileUri}</code></td>
+                  <td className="p-2">{new Date(e.createdAt).toLocaleString()}</td>
+                  <td className="p-2">
+                    <div className="flex flex-wrap gap-2">
+                      {onRunWith && <Button variant="ghost" onClick={() => onRunWith(e.id)}>Run</Button>}
+                      {onSetPreferred && <Button variant="ghost" onClick={() => onSetPreferred(e.id)}>{isPreferred ? 'Preferred' : 'Set preferred'}</Button>}
+                      <Button variant="ghost" onClick={() => openInspect(e.id)}>Inspect</Button>
+                      {abs
+                        ? <a className="px-3 py-1.5 text-sm rounded-md hover:bg-muted" target="_blank" rel="noopener noreferrer" href={abs}>Download</a>
+                        : <span className="px-3 py-1.5 text-sm rounded-md opacity-50">Download</span>
+                      }
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Inspect Drawer/Modal (very light) */}
+      {inspectId && (
+        <div className="fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setInspectId(null)} />
+          <div className="absolute inset-0 flex items-center justify-center p-4">
+            <div className="w-full max-w-2xl rounded-lg border border-border/50 bg-bg p-4 dark:bg-zinc-900">
+              <div className="flex items-center justify-between mb-2">
+                <div className="font-medium">Environment variables</div>
+                <div className="flex gap-2">
+                  <Button variant="ghost" onClick={() => copyVars()} disabled={!vars || vars.length === 0}>Copy</Button>
+                  <Button variant="ghost" onClick={() => setInspectId(null)}>Close</Button>
+                </div>
+              </div>
+              {!vars
+                ? <div className="text-sm opacity-70">Loading…</div>
+                : vars.length === 0
+                  ? <div className="text-sm opacity-70">No variables (or preview unavailable).</div>
+                  : (
+                    <div className="overflow-x-auto rounded border border-border/40">
+                      <table className="w-full text-sm">
+                        <thead className="bg-muted/50"><tr><th className="p-2 text-left">Key</th><th className="p-2 text-left">Value</th><th className="p-2">Enabled</th></tr></thead>
+                        <tbody>
+                          {vars.map(v => (
+                            <tr key={v.key} className="border-t border-border/40">
+                              <td className="p-2 font-mono">{v.key}</td>
+                              <td className="p-2 font-mono truncate max-w-[420px]">{v.value}</td>
+                              <td className="p-2 text-center">{v.enabled ? 'Yes' : 'No'}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )
+              }
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
+

--- a/web/src/components/runs/QuickRunButton.tsx
+++ b/web/src/components/runs/QuickRunButton.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/components/ui/Button';
 import { RunDialog } from '@/components/runs/RunDialog';
 import { useCollectionDetail } from '@/features/collections/queries';
+import { getPreferredEnvId } from '@/features/collections/envPref';
 
 export function QuickRunButton({ collectionId }: { collectionId: string }) {
   const [open, setOpen] = useState(false);
-  const { data, isLoading } = useCollectionDetail(collectionId, false);
+  const { data } = useCollectionDetail(collectionId, false);
+
+  const initialEnvId = useMemo(() => {
+    const pref = getPreferredEnvId(collectionId);
+    if (pref) return pref;
+    const def = data?.envs?.find(e => e.isDefault)?.id;
+    return def;
+  }, [collectionId, data?.envs]);
 
   return (
     <>
@@ -18,6 +26,7 @@ export function QuickRunButton({ collectionId }: { collectionId: string }) {
           onOpenChange={setOpen}
           collectionId={collectionId}
           envs={data?.envs ?? []}
+          initialEnvId={initialEnvId}
         />
       )}
     </>

--- a/web/src/features/collections/envPref.ts
+++ b/web/src/features/collections/envPref.ts
@@ -1,0 +1,28 @@
+'use client';
+
+const KEY = 'env-pref:';
+
+export function getPreferredEnvId(collectionId: string): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const v = localStorage.getItem(KEY + collectionId);
+    return v || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function setPreferredEnvId(collectionId: string, envId: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(KEY + collectionId, envId);
+  } catch {}
+}
+
+export function clearPreferredEnvId(collectionId: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(KEY + collectionId);
+  } catch {}
+}
+

--- a/web/src/features/collections/envUtils.ts
+++ b/web/src/features/collections/envUtils.ts
@@ -1,0 +1,29 @@
+'use client';
+
+export function toAbsoluteUri(fileUri: string): string | null {
+  if (!fileUri) return null;
+  if (fileUri.startsWith('http://') || fileUri.startsWith('https://')) return fileUri;
+  if (fileUri.startsWith('/')) {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+    return base.replace(/\/$/, '') + fileUri;
+  }
+  return null; // not fetchable from the browser
+}
+
+/** Minimal Postman env parser: { name, values: [{key,value,enabled}] } */
+export type ParsedEnvVar = { key: string; value: string; enabled: boolean };
+export function parsePostmanEnv(json: any): ParsedEnvVar[] {
+  try {
+    const vals = Array.isArray(json?.values) ? json.values : [];
+    return vals
+      .map((v: any) => ({
+        key: String(v?.key ?? ''),
+        value: String(v?.value ?? ''),
+        enabled: !!(v?.enabled ?? true),
+      }))
+      .filter((x: ParsedEnvVar) => !!x.key);
+  } catch {
+    return [];
+  }
+}
+

--- a/web/test/env.parse.test.ts
+++ b/web/test/env.parse.test.ts
@@ -1,0 +1,16 @@
+import { parsePostmanEnv } from '@/features/collections/envUtils';
+
+test('parses Postman env values', () => {
+  const json = {
+    name: 'dev',
+    values: [
+      { key: 'baseUrl', value: 'http://x', type: 'text', enabled: true },
+      { key: 'token', value: 'abc', type: 'text', enabled: false },
+      { key: '', value: 'ignore' }
+    ]
+  };
+  const vars = parsePostmanEnv(json);
+  expect(vars.length).toBe(2);
+  expect(vars[0]).toEqual({ key: 'baseUrl', value: 'http://x', enabled: true });
+  expect(vars[1]).toEqual({ key: 'token', value: 'abc', enabled: false });
+});

--- a/web/test/env.pref.test.ts
+++ b/web/test/env.pref.test.ts
@@ -1,0 +1,10 @@
+import { getPreferredEnvId, setPreferredEnvId, clearPreferredEnvId } from '@/features/collections/envPref';
+
+test('stores and retrieves preferred env per collection', () => {
+  const col = 'col_abc';
+  expect(getPreferredEnvId(col)).toBeUndefined();
+  setPreferredEnvId(col, 'env_1');
+  expect(getPreferredEnvId(col)).toBe('env_1');
+  clearPreferredEnvId(col);
+  expect(getPreferredEnvId(col)).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- allow setting and persisting a preferred environment per collection
- add environment table actions: run, set preferred, inspect, download
- preselect preferred or default environment when running collections (incl. quick run)
- add env util helpers and tests

## Testing
- `pnpm -C web i`
- `pnpm -C web test:unit`
- `pnpm -C web test:e2e` *(fails: tests require running backend and app server)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6987570c83268b73f158e2974e07