### PR TITLE
feat: add skeletons, copy actions, and error fallback

### DIFF
--- a/web/app/collections/page.tsx
+++ b/web/app/collections/page.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { UploadCollectionDialog } from '@/components/collections/UploadCollectionDialog';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { TableSkeleton } from '@/components/skeletons/TableSkeleton';
+import { ErrorPanel } from '@/components/common/ErrorPanel';
 
 export default function CollectionsPage() {
   const params = useSearchParams();
@@ -43,9 +45,9 @@ export default function CollectionsPage() {
       <div className="flex items-center gap-3">
         <Input placeholder="Search collections…" value={q} onChange={(e) => onSearchChange(e.target.value)} />
       </div>
-      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load collections.</div>}
+      {isError && <ErrorPanel message="Failed to load collections." />}
       {isLoading ? (
-        <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+        <TableSkeleton rows={8} />
       ) : (
         <>
           <CollectionsTable items={items} />

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { useCollectionsOverview, useTopFailingRequests } from '@/features/dashbo
 import { CollectionHealthCard } from '@/components/dashboard/CollectionHealthCard';
 import { TopFailingRequests } from '@/components/dashboard/TopFailingRequests';
 import Link from 'next/link';
+import { CardsSkeleton } from '@/components/skeletons/CardsSkeleton';
+import { ErrorPanel } from '@/components/common/ErrorPanel';
 
 export default function DashboardPage() {
   const health = useQuery({
@@ -44,9 +46,9 @@ export default function DashboardPage() {
           <Link href="/collections" className="text-sm text-primary hover:underline">View all →</Link>
         </div>
 
-        {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load collections.</div>}
+        {isError && <ErrorPanel message="Failed to load collections." />}
         {isLoading ? (
-          <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+          <CardsSkeleton count={6} />
         ) : items.length === 0 ? (
           <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">
             No collections yet. Go to <Link className="text-primary hover:underline" href="/collections">Collections</Link> to upload your first one.

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error('Route error:', error);
+  }, [error]);
+
+  return (
+    <html>
+      <body className="min-h-screen p-6 bg-bg dark:bg-bg-dark text-black dark:text-white">
+        <div className="max-w-2xl mx-auto space-y-4">
+          <h1 className="text-2xl font-semibold">Something went wrong</h1>
+          <div className="rounded border border-red-500/40 p-4">
+            <div className="text-sm text-red-600">{error.message || 'Unexpected error'}</div>
+            {error.digest && <div className="text-xs opacity-70 mt-1">Digest: <code>{error.digest}</code></div>}
+          </div>
+          <div className="flex gap-2">
+            <button className="px-3 py-2 text-sm rounded-md bg-primary text-white" onClick={() => reset()}>Try again</button>
+            <Link href="/dashboard" className="px-3 py-2 text-sm rounded-md border border-border/50 hover:bg-muted">Go to Dashboard</Link>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -7,13 +7,15 @@ import { RunHeader } from '@/components/runs/RunHeader';
 import { RunTimeline } from '@/components/runs/RunTimeline';
 import { AssertionsPanel } from '@/components/runs/AssertionsPanel';
 import { useEffect, useMemo, useState } from 'react';
+import { RunConsoleSkeleton } from '@/components/skeletons/RunConsoleSkeleton';
+import { ErrorPanel } from '@/components/common/ErrorPanel';
 
 const TERMINAL: string[] = ['success','partial','fail','timeout','error','cancelled'];
 
 export default function RunPage({ params }: { params: { runId: string } }) {
   const runId = params.runId;
 
-  const { data: run } = useRun(runId);
+  const { data: run, isError } = useRun(runId);
   const cancelMut = useCancelRun();
 
   // Stream state
@@ -43,32 +45,39 @@ export default function RunPage({ params }: { params: { runId: string } }) {
 
   return (
     <div className="p-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Run <span className="font-mono text-base">#{runId.slice(0, 8)}</span></h1>
-        <Link href="/runs" className="text-sm text-primary hover:underline">← Runs</Link>
-      </div>
+      {!run && <RunConsoleSkeleton />}
+      {isError && <ErrorPanel message="Failed to load run." />}
 
-      <RunHeader
-        run={run}
-        connected={connected}
-        cancelling={cancelMut.isPending}
-        onCancel={() => cancelMut.mutate(runId)}
-      />
+      {run && (
+        <>
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-semibold">Run <span className="font-mono text-base">#{runId.slice(0, 8)}</span></h1>
+            <Link href="/runs" className="text-sm text-primary hover:underline">← Runs</Link>
+          </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div>
-          <h2 className="text-sm font-medium mb-2">Timeline</h2>
-          <RunTimeline
-            steps={steps}
-            selectedStepId={selectedStepId}
-            onSelect={setSelectedStepId}
+          <RunHeader
+            run={run}
+            connected={connected}
+            cancelling={cancelMut.isPending}
+            onCancel={() => cancelMut.mutate(runId)}
           />
-        </div>
-        <div>
-          <h2 className="text-sm font-medium mb-2">Assertions</h2>
-          <AssertionsPanel assertions={assertions} />
-        </div>
-      </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <div>
+              <h2 className="text-sm font-medium mb-2">Timeline</h2>
+              <RunTimeline
+                steps={steps}
+                selectedStepId={selectedStepId}
+                onSelect={setSelectedStepId}
+              />
+            </div>
+            <div>
+              <h2 className="text-sm font-medium mb-2">Assertions</h2>
+              <AssertionsPanel assertions={assertions} />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -7,6 +7,8 @@ import { RunsTable } from '@/components/runs/RunsTable';
 import { CollectionSelect } from '@/components/runs/CollectionSelect';
 import { RunsPagination } from '@/components/runs/RunsPagination';
 import { Input } from '@/components/ui/Input';
+import { TableSkeleton } from '@/components/skeletons/TableSkeleton';
+import { ErrorPanel } from '@/components/common/ErrorPanel';
 
 const STATUSES = ['all','queued','running','success','partial','timeout','error','cancelled'] as const;
 
@@ -74,10 +76,10 @@ export default function RunsPage() {
         </div>
       </div>
 
-      {isError && <div className="rounded border border-red-500/40 p-3 text-sm text-red-600">Failed to load runs.</div>}
+      {isError && <ErrorPanel message="Failed to load runs." />}
 
       {isLoading ? (
-        <div className="rounded-lg border border-border/40 p-6 text-sm opacity-75">Loading…</div>
+        <TableSkeleton rows={10} />
       ) : (
         <>
           <RunsTable items={filteredItems} collectionNameOf={collectionNameOf} />

--- a/web/e2e/copy-link.spec.ts
+++ b/web/e2e/copy-link.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('copy run link copies to clipboard', async ({ page, context }) => {
+  // Grant clipboard permissions for this test
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: 'http://localhost:3000' });
+
+  // Ensure there is at least one run
+  await page.goto('/collections');
+  const collName = 'Web FE Test Collection';
+  const exists = await page.getByRole('link', { name: collName }).count();
+  if (!exists) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../..', 'fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: collName })).toBeVisible({ timeout: 10000 });
+  }
+  await page.getByRole('link', { name: collName }).click();
+  await page.getByRole('button', { name: 'Run collection' }).click();
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // Copy run link
+  await page.getByRole('button', { name: 'Copy run link' }).click();
+
+  // Verify clipboard
+  const text = await page.evaluate(() => navigator.clipboard.readText());
+  expect(text).toMatch(/\/runs\/[a-zA-Z0-9_-]+$/);
+});

--- a/web/src/components/common/ErrorPanel.tsx
+++ b/web/src/components/common/ErrorPanel.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/Button';
+
+export function ErrorPanel({ message = 'Failed to load data.' }: { message?: string }) {
+  const router = useRouter();
+  return (
+    <div className="rounded border border-red-500/40 p-3 text-sm text-red-600 flex items-center justify-between">
+      <div>{message}</div>
+      <div className="flex gap-2">
+        <Button variant="ghost" onClick={() => router.refresh()}>Retry</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/runs/RunHeader.tsx
+++ b/web/src/components/runs/RunHeader.tsx
@@ -3,6 +3,9 @@
 import type { Run } from '@/features/runs/types';
 import { RunStatusBadge } from './RunStatusBadge';
 import { Button } from '@/components/ui/Button';
+import { CopyButton } from '@/components/ui/CopyButton';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
 export function RunHeader({
   run,
@@ -23,11 +26,29 @@ export function RunHeader({
           <div className="text-sm opacity-70">
             Health: <span className="font-mono">{run?.health ?? '-'}</span>
           </div>
-          <div className={`text-xs rounded px-1.5 py-0.5 ${connected ? 'bg-emerald-600 text-white' : 'bg-zinc-600 text-white'}`}>
+          <div
+            className={`text-xs rounded px-1.5 py-0.5 ${connected ? 'bg-emerald-600 text-white' : 'bg-zinc-600 text-white'}`}
+            title={connected ? 'Receiving live events via SSE' : 'Falling back to periodic polling'}
+          >
             {connected ? 'LIVE' : 'DISCONNECTED'}
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {run?.id && (
+            <>
+              <CopyButton label="Copy run ID" copiedLabel="Run ID copied" text={run.id} />
+              <CopyButton
+                label="Copy run link"
+                copiedLabel="Link copied"
+                text={typeof window !== 'undefined' ? window.location.href : `${API_BASE}/runs/${run?.id}`}
+              />
+              <CopyButton
+                label="Copy cancel cURL"
+                copiedLabel="cURL copied"
+                text={`curl -X POST "${API_BASE}/api/runs/${run?.id}/cancel" -H "content-type: application/json" -d '{}'`}
+              />
+            </>
+          )}
           <Button variant="ghost" onClick={onCancel} disabled={cancelling || !run || ['success','partial','fail','timeout','error','cancelled'].includes(run.status)}>
             {cancelling ? 'Cancelling…' : 'Cancel'}
           </Button>

--- a/web/src/components/skeletons/CardsSkeleton.tsx
+++ b/web/src/components/skeletons/CardsSkeleton.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export function CardsSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="rounded-lg border border-border/40 p-4 space-y-3">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-64" />
+          <div className="grid grid-cols-2 gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <Skeleton className="h-8 w-28" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/skeletons/RunConsoleSkeleton.tsx
+++ b/web/src/components/skeletons/RunConsoleSkeleton.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export function RunConsoleSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="rounded border border-border/40 p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Skeleton className="h-[60vh]" />
+        <Skeleton className="h-[60vh]" />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/skeletons/TableSkeleton.tsx
+++ b/web/src/components/skeletons/TableSkeleton.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+export function TableSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="rounded-lg border border-border/40 p-2">
+      <div className="grid grid-cols-6 gap-2 p-2">
+        <Skeleton className="h-4 w-24 col-span-1" />
+        <Skeleton className="h-4 w-24 col-span-1" />
+        <Skeleton className="h-4 w-24 col-span-1" />
+        <Skeleton className="h-4 w-24 col-span-1" />
+        <Skeleton className="h-4 w-24 col-span-1" />
+        <Skeleton className="h-4 w-24 col-span-1" />
+      </div>
+      <div className="space-y-2 p-2">
+        {Array.from({ length: rows }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/CopyButton.tsx
+++ b/web/src/components/ui/CopyButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Button } from './Button';
+import { useCopy } from '@/hooks/useCopy';
+
+export function CopyButton({
+  text,
+  label = 'Copy',
+  copiedLabel = 'Copied',
+  className,
+}: {
+  text: string;
+  label?: string;
+  copiedLabel?: string;
+  className?: string;
+}) {
+  const copy = useCopy();
+  return (
+    <Button
+      variant="ghost"
+      className={className}
+      onClick={async () => {
+        await copy(text, copiedLabel);
+      }}
+      aria-label={label}
+      title={label}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { twMerge } from 'tailwind-merge';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={twMerge(
+        'animate-pulse rounded bg-zinc-200/70 dark:bg-zinc-700/60',
+        className,
+      )}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/hooks/useCopy.ts
+++ b/web/src/hooks/useCopy.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useToast } from '@/components/ui/Toast';
+
+export function useCopy() {
+  const { toast } = useToast();
+  return async (text: string, label = 'Copied') => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // Fallback
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      toast({ title: label });
+      return true;
+    } catch (e: any) {
+      toast({ title: 'Copy failed', description: e?.message || 'Unknown error' });
+      return false;
+    }
+  };
+}

--- a/web/test/copy.helper.test.ts
+++ b/web/test/copy.helper.test.ts
@@ -1,0 +1,22 @@
+import { useCopy } from '@/hooks/useCopy';
+import { renderHook, act } from '@testing-library/react';
+
+const originalClipboard = global.navigator.clipboard;
+
+beforeEach(() => {
+  // @ts-ignore
+  global.navigator.clipboard = { writeText: jest.fn().mockResolvedValue(undefined) };
+});
+afterEach(() => {
+  // @ts-ignore
+  global.navigator.clipboard = originalClipboard;
+});
+
+test('useCopy writes to clipboard and returns true', async () => {
+  const { result } = renderHook(() => useCopy());
+  let ok = false;
+  await act(async () => {
+    ok = await result.current('hello', 'copied');
+  });
+  expect(ok).toBe(true);
+});

--- a/web/test/error.panel.test.tsx
+++ b/web/test/error.panel.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { ErrorPanel } from '@/components/common/ErrorPanel';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}));
+
+test('ErrorPanel renders retry button', () => {
+  render(<ErrorPanel message="Boom" />);
+  expect(screen.getByText('Boom')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Clipboard utilities and button component
- introduce reusable skeletons and error panel
- wire skeletons, error panel, and copy actions into dashboard, collections, and runs

## Testing
- `pnpm test:unit`
- `pnpm dev` *(manual)*
- `pnpm test:e2e` *(fails: collection-detail.spec.ts, collections.spec.ts, copy-link.spec.ts, dashboard-run-now.spec.ts, envs-preferred.spec.ts, run-console.sse.spec.ts, run-launcher.spec.ts, runs-list.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6fe1a77883268efac26efb8d5c8b