### PR TITLE
feat: add accessibility utilities and tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
         specifier: ^4.5.4
         version: 4.5.7(@types/react@18.3.24)(react@18.3.1)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.10.2(playwright-core@1.55.0)
       '@playwright/test':
         specifier: ^1.46.0
         version: 1.55.0
@@ -190,6 +193,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)
+      axe-core:
+        specifier: ^4.10.3
+        version: 4.10.3
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -199,6 +205,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.11)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+      jest-axe:
+        specifier: ^10.0.0
+        version: 10.0.0
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -248,6 +257,11 @@ packages:
   '@angular-devkit/schematics@17.3.11':
     resolution: {integrity: sha512-I5wviiIqiFwar9Pdk30Lujk8FczEEc18i22A5c6Z9lbmhPQdTroDnEQdsfXjy404wPe8H62s0I15o4pmMGfTYQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@axe-core/playwright@4.10.2':
+    resolution: {integrity: sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1635,6 +1649,10 @@ packages:
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  axe-core@4.10.2:
+    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
+    engines: {node: '>=4'}
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
@@ -3028,6 +3046,10 @@ packages:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
+  jest-axe@10.0.0:
+    resolution: {integrity: sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==}
+    engines: {node: '>= 16.0.0'}
+
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3093,6 +3115,10 @@ packages:
 
   jest-leak-detector@29.7.0:
     resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.2.2:
+    resolution: {integrity: sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@29.7.0:
@@ -4934,6 +4960,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@axe-core/playwright@4.10.2(playwright-core@1.55.0)':
+    dependencies:
+      axe-core: 4.10.3
+      playwright-core: 1.55.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -6462,6 +6493,8 @@ snapshots:
   aws4@1.12.0: {}
 
   aws4@1.13.2: {}
+
+  axe-core@4.10.2: {}
 
   axe-core@4.10.3: {}
 
@@ -8135,6 +8168,13 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
+  jest-axe@10.0.0:
+    dependencies:
+      axe-core: 4.10.2
+      chalk: 4.1.2
+      jest-matcher-utils: 29.2.2
+      lodash.merge: 4.6.2
+
   jest-changed-files@29.7.0:
     dependencies:
       execa: 5.1.1
@@ -8280,6 +8320,13 @@ snapshots:
 
   jest-leak-detector@29.7.0:
     dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.2.2:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
 

--- a/web/app/collections/[id]/page.tsx
+++ b/web/app/collections/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useState, useMemo } from 'react';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import { useCollectionDetail } from '@/features/collections/queries';
 import { Input } from '@/components/ui/Input';
 import { RequestsTree } from '@/components/collections/RequestsTree';
@@ -37,6 +38,21 @@ export default function CollectionDetailPage({ params }: { params: { id: string 
   const withRequests = tab === 'requests';
 
   const { data, isLoading, isError } = useCollectionDetail(id, withRequests);
+
+  useShortcuts([
+    { combo: 'r', handler: () => setRunOpen(true) },
+    {
+      combo: 'slash',
+      handler: () => {
+        // focus requests filter if tab is requests
+        if (tab === 'requests') {
+          const el = document.getElementById('requests-filter') as HTMLInputElement | null;
+          el?.focus();
+        }
+      },
+      when: () => tab === 'requests',
+    },
+  ], [tab]);
 
   const header = useMemo(() => {
     if (!data) return null;
@@ -104,8 +120,10 @@ export default function CollectionDetailPage({ params }: { params: { id: string 
           {tab === 'requests' && (
             <>
               <div className="flex items-center gap-3">
-                <Input placeholder="Filter by name or path…" value={filter} onChange={(e) => setFilter(e.target.value)} />
+                <label htmlFor="requests-filter" className="sr-only">Filter requests</label>
+                <Input id="requests-filter" placeholder="Filter by name or path…" value={filter} onChange={(e) => setFilter(e.target.value)} />
                 <div className="text-sm opacity-70">Total indexed: {data._count.requests}</div>
+                <span className="text-xs opacity-60">Shortcuts: R to run, / to search</span>
               </div>
               <RequestsTree collectionId={id} requests={data.requests || []} filter={filter} />
             </>

--- a/web/app/collections/page.tsx
+++ b/web/app/collections/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCollectionsList } from '@/features/collections/queries';
 import { CollectionsTable } from '@/components/collections/CollectionsTable';
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { UploadCollectionDialog } from '@/components/collections/UploadCollectionDialog';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import { TableSkeleton } from '@/components/skeletons/TableSkeleton';
 import { ErrorPanel } from '@/components/common/ErrorPanel';
 
@@ -23,6 +24,7 @@ export default function CollectionsPage() {
 
   const { data, isLoading, isError } = useCollectionsList(debouncedQ, page, 10);
   const [open, setOpen] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const onSearchChange = (v: string) => {
     setQ(v);
@@ -31,6 +33,11 @@ export default function CollectionsPage() {
     sp.set('page', '1');
     router.push(`/collections?${sp.toString()}`);
   };
+
+  useShortcuts([
+    { combo: 'u', handler: () => setOpen(true) },
+    { combo: 'slash', handler: () => searchRef.current?.focus() },
+  ], [params.toString()]);
 
   const total = data?.total ?? 0;
   const limit = data?.limit ?? 10;
@@ -43,7 +50,9 @@ export default function CollectionsPage() {
         <Button onClick={() => setOpen(true)} aria-haspopup="dialog">Upload Collection</Button>
       </div>
       <div className="flex items-center gap-3">
-        <Input placeholder="Search collections…" value={q} onChange={(e) => onSearchChange(e.target.value)} />
+        <label htmlFor="collections-search" className="sr-only">Search collections</label>
+        <Input id="collections-search" ref={searchRef} placeholder="Search collections…" value={q} onChange={(e) => onSearchChange(e.target.value)} />
+        <span className="text-xs opacity-60">Shortcut: /</span>
       </div>
       {isError && <ErrorPanel message="Failed to load collections." />}
       {isLoading ? (

--- a/web/e2e/a11y-shortcuts.spec.ts
+++ b/web/e2e/a11y-shortcuts.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { analyze } from '@axe-core/playwright';
+import path from 'path';
+
+test('skip link, shortcuts, and axe scan on key pages', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: 'http://localhost:3000' });
+
+  // Ensure a collection exists
+  await page.goto('/collections');
+  const collName = 'Web FE Test Collection';
+  const exists = await page.getByRole('link', { name: collName }).count();
+  if (!exists) {
+    await page.getByRole('button', { name: 'Upload Collection' }).click();
+    const colPath = path.resolve(__dirname, '../..', 'fixtures/postman/simple.collection.json');
+    await page.locator('input[type="file"][name="collection"]').setInputFiles(colPath);
+    await page.getByRole('button', { name: 'Upload' }).click();
+    await expect(page.getByRole('link', { name: collName })).toBeVisible({ timeout: 10000 });
+  }
+
+  // Axe on dashboard
+  await page.goto('/dashboard');
+  const results = await analyze(page, { rules: { 'color-contrast': { enabled: false } } }); // allow for theme variance
+  expect(results.violations).toEqual([]);
+
+  // Skip link works
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: 'Skip to content' })).toBeVisible();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#content')).toBeFocused();
+
+  // Collections shortcuts: 'u' opens dialog, 'esc' closes, '/' focuses search
+  await page.goto('/collections');
+  await page.keyboard.press('u');
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await page.keyboard.press('/');
+  await expect(page.locator('#collections-search')).toBeFocused();
+
+  // Collection detail: 'r' opens Run dialog and focuses env select
+  await page.getByRole('link', { name: collName }).click();
+  await expect(page.getByRole('heading', { name: collName })).toBeVisible();
+  await page.keyboard.press('r');
+  await expect(page.getByRole('dialog')).toBeVisible();
+  // select should be focused due to autoFocus + dialog focus
+  await expect(page.locator('select[aria-label="Environment"]')).toBeFocused();
+  await page.keyboard.press('Escape');
+
+  // Start a run quickly and test timeline navigation keys
+  await page.keyboard.press('r');
+  await page.getByRole('button', { name: 'Start Run' }).click();
+  await expect(page).toHaveURL(/\/runs\/.+/);
+
+  // Wait for at least one timeline item
+  await expect(page.getByRole('heading', { name: 'Timeline' })).toBeVisible();
+  await expect(page.locator('#timeline-list')).toBeVisible({ timeout: 15000 });
+  // Focus list and use arrows
+  await page.locator('#timeline-list').focus();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowUp');
+  // 'a' focuses assertions panel
+  await page.keyboard.press('a');
+  await expect(page.locator('#assertions-panel')).toBeFocused();
+});

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "test:unit": "jest --passWithNoTests",
+    "test:a11y": "jest --passWithNoTests -i a11y",
     "test:e2e": "playwright test",
     "test": "pnpm test:unit && pnpm test:e2e",
     "postinstall": "playwright install --with-deps || true"
@@ -18,11 +19,12 @@
     "next-themes": "^0.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "tailwind-merge": "^2.5.2",
     "zod": "^3.23.8",
-    "zustand": "^4.5.4",
-    "tailwind-merge": "^2.5.2"
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@playwright/test": "^1.46.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
@@ -31,9 +33,11 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "autoprefixer": "^10.4.19",
+    "axe-core": "^4.10.3",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",
     "jest": "^29.7.0",
+    "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.38",
     "prettier": "^3.3.3",

--- a/web/src/components/collections/RequestsTree.tsx
+++ b/web/src/components/collections/RequestsTree.tsx
@@ -40,13 +40,13 @@ export function RequestsTree({
   const Folder = ({ node }: { node: Extract<TreeNode, { type: 'folder' }> }) => {
     const isOpen = !!open[node.key];
     return (
-      <div className="ml-2">
+      <div className="ml-2" role="treeitem" aria-expanded={isOpen} aria-label={node.name}>
         <div className="flex items-center gap-2 py-1 cursor-pointer select-none" onClick={() => setOpen({ ...open, [node.key]: !isOpen })}>
-          <span className="text-xs">{isOpen ? '▾' : '▸'}</span>
+          <span className="text-xs" aria-hidden>{isOpen ? '▾' : '▸'}</span>
           <span className="font-medium">{node.name}</span>
         </div>
         {isOpen && (
-          <div className="ml-4 border-l border-border/30">
+          <div className="ml-4 border-l border-border/30" role="group">
             {node.children.map(c => c.type === 'folder'
               ? <Folder key={c.key} node={c} />
               : <RequestRow key={c.key} node={c} />
@@ -89,11 +89,11 @@ export function RequestsTree({
       <div className="flex items-center justify-between mb-2">
         <div className="text-sm opacity-70">{filtered.length} request(s)</div>
         <div className="flex gap-2">
-          <Button variant="ghost" onClick={expandAll}>Expand all</Button>
-          <Button variant="ghost" onClick={collapseAll}>Collapse all</Button>
+          <Button variant="ghost" onClick={expandAll} aria-label="Expand all folders">Expand all</Button>
+          <Button variant="ghost" onClick={collapseAll} aria-label="Collapse all folders">Collapse all</Button>
         </div>
       </div>
-      <div className="rounded border border-border/40 p-2">
+      <div className="rounded border border-border/40 p-2" role="tree" aria-label="Collection requests">
         {tree.length === 0 ? (
           <div className="p-4 text-sm opacity-70">No requests match your filter.</div>
         ) : (

--- a/web/src/components/common/LiveRegion.tsx
+++ b/web/src/components/common/LiveRegion.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export function LiveRegion({ message }: { message: string | null }) {
+  const [msg, setMsg] = useState<string>('');
+  useEffect(() => {
+    if (message) setMsg(message);
+  }, [message]);
+  return (
+    <div aria-live="polite" aria-atomic="true" className="sr-only" id="live-region">
+      {msg}
+    </div>
+  );
+}

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -6,20 +6,29 @@ import { ThemeToggle } from './ThemeToggle';
 export function Shell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen grid grid-cols-[220px_1fr] grid-rows-[56px_1fr]">
-      <header className="col-span-2 h-14 border-b border-border/40 flex items-center justify-between px-4">
-        <Link href="/dashboard" className="font-semibold">AUOB</Link>
+      {/* Skip link */}
+      <a href="#content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 bg-primary text-white rounded px-3 py-1">
+        Skip to content
+      </a>
+
+      <header className="col-span-2 h-14 border-b border-border/40 flex items-center justify-between px-4" role="banner">
+        <Link href="/dashboard" className="font-semibold" aria-label="AUOB home">AUOB</Link>
         <div className="flex gap-2 items-center">
           <ThemeToggle />
         </div>
       </header>
+
       <aside className="border-r border-border/40 p-3">
-        <nav className="space-y-1">
+        <nav className="space-y-1" role="navigation" aria-label="Primary">
           <Link className="block rounded px-2 py-1 hover:bg-muted" href="/dashboard">Dashboard</Link>
           <Link className="block rounded px-2 py-1 hover:bg-muted" href="/collections">Collections</Link>
           <Link className="block rounded px-2 py-1 hover:bg-muted" href="/runs">Runs</Link>
         </nav>
       </aside>
-      <main className="p-0">{children}</main>
+
+      <main id="content" role="main" className="p-0" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/web/src/components/runs/AssertionsPanel.tsx
+++ b/web/src/components/runs/AssertionsPanel.tsx
@@ -4,10 +4,10 @@ import type { RunAssertionView } from '@/features/runs/types';
 
 export function AssertionsPanel({ assertions }: { assertions: RunAssertionView[] }) {
   if (!assertions.length) {
-    return <div className="rounded border border-border/40 p-4 text-sm opacity-70">No assertions for this step.</div>;
+    return <div id="assertions-panel" tabIndex={0} className="rounded border border-border/40 p-4 text-sm opacity-70">No assertions for this step.</div>;
   }
   return (
-    <div className="rounded border border-border/40">
+    <div id="assertions-panel" tabIndex={0} className="rounded border border-border/40">
       <ul className="divide-y divide-border/40">
         {assertions.map((a, i) => (
           <li key={`${a.name}-${i}`} className="p-3">

--- a/web/src/components/runs/RunDialog.tsx
+++ b/web/src/components/runs/RunDialog.tsx
@@ -75,6 +75,7 @@ export function RunDialog({ open, onOpenChange, collectionId, envs, initialEnvId
           <select
             id="env-select"
             aria-label="Environment"
+            autoFocus
             className="h-9 w-full rounded-md border border-border/50 bg-bg px-3 text-sm dark:bg-zinc-900"
             value={environmentId}
             onChange={(e) => setEnvironmentId(e.target.value)}

--- a/web/src/components/runs/RunTimeline.tsx
+++ b/web/src/components/runs/RunTimeline.tsx
@@ -14,15 +14,35 @@ export function RunTimeline({
   if (!steps.length) {
     return <div className="rounded border border-border/40 p-4 text-sm opacity-70">No steps yet…</div>;
   }
+  const onKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+    if (!selectedStepId) return;
+    const idx = steps.findIndex(s => s.id === selectedStepId);
+    if (e.key === 'ArrowDown') {
+      const next = steps[Math.min(idx + 1, steps.length - 1)];
+      if (next) onSelect(next.id);
+    } else if (e.key === 'ArrowUp') {
+      const prev = steps[Math.max(idx - 1, 0)];
+      if (prev) onSelect(prev.id);
+    }
+  };
   return (
     <div className="rounded border border-border/40">
-      <ul className="max-h-[60vh] overflow-auto divide-y divide-border/40">
+      <ul
+        id="timeline-list"
+        role="listbox"
+        aria-label="Run steps"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        className="max-h-[60vh] overflow-auto divide-y divide-border/40 outline-none"
+      >
         {steps.map((s) => {
           const isSel = s.id === selectedStepId;
           const statusColor = s.status === 'success' ? 'text-emerald-600' : 'text-red-600';
           return (
             <li
               key={s.id}
+              role="option"
+              aria-selected={isSel}
               className={`p-3 cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-muted/60' : ''}`}
               onClick={() => onSelect(s.id)}
             >

--- a/web/src/components/ui/Dialog.tsx
+++ b/web/src/components/ui/Dialog.tsx
@@ -1,23 +1,38 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export function Dialog({
   open, onClose, children, title,
 }: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const prevFocus = useRef<HTMLElement | null>(null);
+  const titleId = 'dlg-title-' + (title?.toLowerCase().replace(/\s+/g, '-') || 'dialog');
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose(); }
-    if (open) document.addEventListener('keydown', onKey);
+    if (open) {
+      document.addEventListener('keydown', onKey);
+      prevFocus.current = document.activeElement as HTMLElement;
+      // focus first focusable
+      setTimeout(() => {
+        const el = ref.current?.querySelector<HTMLElement>('[autofocus],select,input,button,textarea,[tabindex]:not([tabindex="-1"])');
+        el?.focus();
+      }, 0);
+    } else {
+      document.removeEventListener('keydown', onKey);
+      prevFocus.current?.focus();
+    }
     return () => document.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50">
+    <div className="fixed inset-0 z-50" aria-labelledby={titleId} role="dialog" aria-modal="true">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
       <div className="absolute inset-0 flex items-center justify-center p-4">
-        <div className={twMerge('w-full max-w-lg rounded-lg border border-border/50 bg-bg p-4 dark:bg-zinc-900')}>
-          {title && <div className="mb-2 text-lg font-medium">{title}</div>}
+        <div ref={ref} className={twMerge('w-full max-w-lg rounded-lg border border-border/50 bg-bg p-4 dark:bg-zinc-900')}>
+          {title && <div id={titleId} className="mb-2 text-lg font-medium">{title}</div>}
           {children}
         </div>
       </div>

--- a/web/src/hooks/useShortcuts.ts
+++ b/web/src/hooks/useShortcuts.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type Binding = {
+  combo: string; // e.g. 'slash', 'u', 'r', 'escape', 'arrowdown', 'arrowup', 'a'
+  handler: (e: KeyboardEvent) => void;
+  when?: () => boolean; // optional guard
+  preventDefault?: boolean;
+};
+
+const keyOf = (e: KeyboardEvent) => e.key.toLowerCase();
+
+export function useShortcuts(bindings: Binding[], deps: unknown[] = []) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const k = keyOf(e);
+      for (const b of bindings) {
+        if (b.combo === k && (!b.when || b.when())) {
+          if (b.preventDefault !== false) e.preventDefault();
+          b.handler(e);
+          break;
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/web/test/a11y.axe.test.tsx
+++ b/web/test/a11y.axe.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Shell } from '@/components/layout/Shell';
+
+expect.extend(toHaveNoViolations);
+
+test('Shell has no critical a11y violations', async () => {
+  const { container } = render(<Shell><div>Content</div></Shell>);
+  const results = await axe(container, { rules: { region: { enabled: true } } });
+  expect(results).toHaveNoViolations();
+});


### PR DESCRIPTION
## Summary
- add global keyboard shortcut hook and live region announcer
- improve landmarks, dialog accessibility, and keyboard navigation across pages
- add jest-axe unit and Playwright accessibility tests

## Testing
- `pnpm -C web test:unit`
- `pnpm -C web test:e2e` *(fails: ENOENT missing fixtures; multiple tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4c12bd483269af701322868f9d4